### PR TITLE
Remove `darwin` from default `bashNative` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ console.log(files); // ['dir/a.txt', ...]
 | `stats`      | `Boolean`         | `false`               | Return `fs.Stats` with `path` property instead of file path. |
 | `onlyFiles`  | `Boolean`         | `false`               | Return only files. |
 | `onlyDirs`   | `Boolean`         | `false`               | Return only directories. |
-| `bashNative` | `String[]`        | `['darwin', 'linux']` | Use bash-powered globbing (2-15x faster on Linux, but slow on BashOnWindows) for specified platforms. See [available values for array](https://nodejs.org/dist/latest-v7.x/docs/api/process.html#process_process_platform). |
+| `bashNative` | `String[]`        | `['linux']` | Use bash-powered globbing (2-15x faster on Linux, but slow on BashOnWindows) for specified platforms. See [available values for array](https://nodejs.org/dist/latest-v7.x/docs/api/process.html#process_process_platform). |
 | `transform`  | `Function`        | `null`                | Allows you to transform a path or `fs.Stats` object before sending to the array. |
 
 ## Compatible with `node-glob`?

--- a/src/fglob.ts
+++ b/src/fglob.ts
@@ -33,7 +33,7 @@ function prepareInput(source: string | string[], options?: IOptions) {
 		stats: false,
 		onlyFiles: false,
 		onlyDirs: false,
-		bashNative: ['darwin', 'linux'],
+		bashNative: ['linux'],
 		transform: null
 	}, options);
 


### PR DESCRIPTION
bash-glob has several issues in OS X. One is the problem of `bash` having the wrong path (cf. https://github.com/micromatch/bash-glob/issues/2, https://github.com/haggholm/bash-glob/commit/90e4c0829e08c5c285fdff24324e9b4813517613), but once that’s fixed, we start seeing different errors:

```
globstar: invalid shell option name
```
Since it’s not generally safe to assume that bash-glob will work in OS X, it should probably not be enabled by *default*, even if you can opt in…?