### PR TITLE
ISSUE-34: Fix micromatch performance

### DIFF
--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -1,7 +1,10 @@
 import micromatch = require('micromatch');
 
+import * as pathUtils from '../../utils/path';
+
 import { IOptions } from '../../managers/options';
 
+import { FilterFunction } from 'readdir-enhanced';
 import { IEntry } from '../../types/entries';
 import { Pattern } from '../../types/patterns';
 
@@ -9,9 +12,16 @@ export default class DeepFilter {
 	constructor(private readonly options: IOptions, private readonly micromatchOptions: micromatch.Options) { }
 
 	/**
+	 * Return filter for directories.
+	 */
+	public getFilter(negative: Pattern[], globstar: boolean): FilterFunction {
+		return (entry: IEntry) => this.filter(entry, negative, globstar);
+	}
+
+	/**
 	 * Returns true if directory must be read.
 	 */
-	public call(entry: IEntry, negative: Pattern[], globstar: boolean): boolean {
+	private filter(entry: IEntry, negative: Pattern[], globstar: boolean): boolean {
 		if (!this.options.deep) {
 			return false;
 		}
@@ -41,20 +51,10 @@ export default class DeepFilter {
 	}
 
 	/**
-	 * Returns true if the last partial of the path starting with a period.
-	 */
-	public isDotDirectory(entry: IEntry): boolean {
-		const pathPartials = entry.path.split('/');
-		const lastPathPartial: string = pathPartials[pathPartials.length - 1];
-
-		return lastPathPartial.startsWith('.');
-	}
-
-	/**
 	 * Returns true for dot directories if the «dot» option is enabled.
 	 */
 	private isFollowedDotDirectory(entry: IEntry): boolean {
-		return !this.options.dot && this.isDotDirectory(entry);
+		return !this.options.dot && pathUtils.isDotDirectory(entry.path);
 	}
 
 	/**

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -1,27 +1,30 @@
 import micromatch = require('micromatch');
 
 import * as pathUtils from '../../utils/path';
+import * as patternUtils from '../../utils/pattern';
 
 import { IOptions } from '../../managers/options';
 
 import { FilterFunction } from 'readdir-enhanced';
 import { IEntry } from '../../types/entries';
-import { Pattern } from '../../types/patterns';
+import { Pattern, PatternRe } from '../../types/patterns';
 
 export default class DeepFilter {
 	constructor(private readonly options: IOptions, private readonly micromatchOptions: micromatch.Options) { }
 
 	/**
-	 * Return filter for directories.
+	 * Returns filter for directories.
 	 */
 	public getFilter(negative: Pattern[], globstar: boolean): FilterFunction {
-		return (entry: IEntry) => this.filter(entry, negative, globstar);
+		const negativeRe: PatternRe[] = patternUtils.convertPatternsToRe(negative, this.micromatchOptions);
+
+		return (entry: IEntry) => this.filter(entry, negativeRe, globstar);
 	}
 
 	/**
 	 * Returns true if directory must be read.
 	 */
-	private filter(entry: IEntry, negative: Pattern[], globstar: boolean): boolean {
+	private filter(entry: IEntry, negativeRe: PatternRe[], globstar: boolean): boolean {
 		if (!this.options.deep) {
 			return false;
 		}
@@ -43,7 +46,7 @@ export default class DeepFilter {
 			return false;
 		}
 
-		if (micromatch.any(entry.path, negative, this.micromatchOptions)) {
+		if (patternUtils.matchAny(entry.path, negativeRe)) {
 			return false;
 		}
 

--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -6,9 +6,11 @@ import EntryFilter from './entry';
 
 import * as optionsManager from '../../managers/options';
 
+import { FilterFunction } from 'readdir-enhanced';
 import { IOptions, IPartialOptions } from '../../managers/options';
+import { Pattern } from '../../types/patterns';
 
-function getFilter(options?: IPartialOptions): EntryFilter {
+function getEntryFilterInstance(options?: IPartialOptions): EntryFilter {
 	const preparedOptions: IOptions = optionsManager.prepare(options);
 
 	return new EntryFilter(preparedOptions, {
@@ -16,10 +18,14 @@ function getFilter(options?: IPartialOptions): EntryFilter {
 	});
 }
 
+function getFilter(positive: Pattern[], negative: Pattern[], options?: IPartialOptions): FilterFunction {
+	return getEntryFilterInstance(options).getFilter(positive, negative);
+}
+
 describe('Providers → Filters → Entry', () => {
 	describe('Constructor', () => {
 		it('should create instance of class', () => {
-			const filter = getFilter();
+			const filter = getEntryFilterInstance();
 
 			assert.ok(filter instanceof EntryFilter);
 		});
@@ -28,69 +34,71 @@ describe('Providers → Filters → Entry', () => {
 	describe('.call', () => {
 		describe('Filter by «unique» option', () => {
 			it('should return true for unique entry when option is enabled', () => {
-				const filter = getFilter({ onlyFiles: false });
+				const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
 				const entry = tests.getFileEntry(false /** dot */);
 
-				const actual = filter.call(entry, ['**/*'], []);
+				const actual = filter(entry);
 
 				assert.ok(actual);
 			});
 
 			it('should return false for non-unique entry when option is enabled', () => {
-				const filter = getFilter({ onlyFiles: false });
+				const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
 				const entry = tests.getFileEntry(false /** dot */);
 
 				// Create index record
-				filter.call(entry, ['**/*'], []);
+				filter(entry);
 
-				const actual = filter.call(entry, ['**/*'], []);
+				const actual = filter(entry);
 
 				assert.ok(!actual);
 			});
 
 			it('should return true for non-unique entry when option is disabled', () => {
-				const filter = getFilter({ onlyFiles: false, unique: false });
+				const filter = getFilter(['**/*'], [], { onlyFiles: false, unique: false });
 
 				const entry = tests.getFileEntry(false /** dot */);
 
 				// Create index record
-				filter.call(entry, ['**/*'], []);
+				filter(entry);
 
-				const actual = filter.call(entry, ['**/*'], []);
+				const actual = filter(entry);
 
 				assert.ok(actual);
 			});
 
 			it('should not build the index when option is disabled', () => {
-				const filter = getFilter({ onlyFiles: false, unique: false });
+				const filterInstance = getEntryFilterInstance({ onlyFiles: false, unique: false });
+
+				const filter = filterInstance.getFilter(['**/*'], []);
 
 				const entry = tests.getFileEntry(false /** dot */);
 
-				filter.call(entry, ['**/*'], []);
+				filter(entry);
 
-				assert.equal(filter.index.size, 0);
+				assert.equal(filterInstance.index.size, 0);
 			});
 		});
 
 		describe('Filter by excluded directories', () => {
 			it('should return false for excluded directory', () => {
-				const filter = getFilter({ onlyFiles: false });
+				const filter = getFilter(['**/*', '!**/directory'], ['**/directory'], { onlyFiles: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-				const actual = filter.call(entry, ['**/*', '!**/directory'], ['**/directory']);
+				const actual = filter(entry);
 
 				assert.ok(!actual);
 			});
 
 			it('should return false for files in excluded directory', () => {
-				const filter = getFilter({ onlyFiles: false });
+				const filter = getFilter(['**/*', '!**/directory/**'], ['**/directory/**'], { onlyFiles: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-				const actual = filter.call(entry, ['**/*', '!**/directory/**'], ['**/directory/**']);
+				const actual = filter(entry);
 
 				assert.ok(!actual);
 			});
@@ -99,41 +107,41 @@ describe('Providers → Filters → Entry', () => {
 		describe('Filter by entry type', () => {
 			describe('The «onlyFiles» option', () => {
 				it('should return true for file when option is enabled', () => {
-					const filter = getFilter();
+					const filter = getFilter(['**/*'], []);
 
 					const entry = tests.getFileEntry(false /** dot */);
 
-					const actual = filter.call(entry, ['**/*'], []);
+					const actual = filter(entry);
 
 					assert.ok(actual);
 				});
 
 				it('should return true for file when option is disabled', () => {
-					const filter = getFilter({ onlyFiles: false });
+					const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
 					const entry = tests.getFileEntry(false /** dot */);
 
-					const actual = filter.call(entry, ['**/*'], []);
+					const actual = filter(entry);
 
 					assert.ok(actual);
 				});
 
 				it('should return false for directory when option is enabled', () => {
-					const filter = getFilter();
+					const filter = getFilter(['**/*'], []);
 
 					const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-					const actual = filter.call(entry, ['**/*'], []);
+					const actual = filter(entry);
 
 					assert.ok(!actual);
 				});
 
 				it('should return true for directory when option is disabled', () => {
-					const filter = getFilter({ onlyFiles: false });
+					const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
 					const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-					const actual = filter.call(entry, ['**/*'], []);
+					const actual = filter(entry);
 
 					assert.ok(actual);
 				});
@@ -141,41 +149,41 @@ describe('Providers → Filters → Entry', () => {
 
 			describe('The «onlyDirectories» option', () => {
 				it('should return false for file when option is enabled', () => {
-					const filter = getFilter({ onlyFiles: false, onlyDirectories: true });
+					const filter = getFilter(['**/*'], [], { onlyFiles: false, onlyDirectories: true });
 
 					const entry = tests.getFileEntry(false /** dot */);
 
-					const actual = filter.call(entry, ['**/*'], []);
+					const actual = filter(entry);
 
 					assert.ok(!actual);
 				});
 
 				it('should return true for file when option is disabled', () => {
-					const filter = getFilter({ onlyFiles: false });
+					const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
 					const entry = tests.getFileEntry(false /** dot */);
 
-					const actual = filter.call(entry, ['**/*'], []);
+					const actual = filter(entry);
 
 					assert.ok(actual);
 				});
 
 				it('should return true for directory when option is enabled', () => {
-					const filter = getFilter({ onlyFiles: false, onlyDirectories: true });
+					const filter = getFilter(['**/*'], [], { onlyFiles: false, onlyDirectories: true });
 
 					const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-					const actual = filter.call(entry, ['**/*'], []);
+					const actual = filter(entry);
 
 					assert.ok(actual);
 				});
 
 				it('should return false for directory when option is disabled', () => {
-					const filter = getFilter();
+					const filter = getFilter(['**/*'], []);
 
 					const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-					const actual = filter.call(entry, ['**/*'], []);
+					const actual = filter(entry);
 
 					assert.ok(!actual);
 				});
@@ -184,41 +192,41 @@ describe('Providers → Filters → Entry', () => {
 
 		describe('Filter by «dot» option', () => {
 			it('should return true for file that starting with a period when option is enabled', () => {
-				const filter = getFilter({ onlyFiles: false, dot: true });
+				const filter = getFilter(['**/*'], [], { onlyFiles: false, dot: true });
 
 				const entry = tests.getFileEntry(true /** dot */);
 
-				const actual = filter.call(entry, ['**/*'], []);
+				const actual = filter(entry);
 
 				assert.ok(actual);
 			});
 
 			it('should return false for file that starting with a period when option is disabled', () => {
-				const filter = getFilter({ onlyFiles: false });
+				const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
 				const entry = tests.getFileEntry(true /** dot */);
 
-				const actual = filter.call(entry, ['**/*'], []);
+				const actual = filter(entry);
 
 				assert.ok(!actual);
 			});
 
 			it('should return true for directory that starting with a period when option is enabled', () => {
-				const filter = getFilter({ onlyFiles: false, dot: true });
+				const filter = getFilter(['**/*'], [], { onlyFiles: false, dot: true });
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);
 
-				const actual = filter.call(entry, ['**/*'], []);
+				const actual = filter(entry);
 
 				assert.ok(actual);
 			});
 
 			it('should return false for directory that starting with a period when option is disabled', () => {
-				const filter = getFilter();
+				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);
 
-				const actual = filter.call(entry, ['**/*'], []);
+				const actual = filter(entry);
 
 				assert.ok(!actual);
 			});
@@ -227,51 +235,51 @@ describe('Providers → Filters → Entry', () => {
 
 	describe('Filter by patterns', () => {
 		it('should return true for file that matched to patterns', () => {
-			const filter = getFilter({ onlyFiles: false });
+			const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
 			const entry = tests.getFileEntry(false /** dot */);
 
-			const actual = filter.call(entry, ['**/*'], []);
+			const actual = filter(entry);
 
 			assert.ok(actual);
 		});
 
 		it('should return false for file that not matched to patterns', () => {
-			const filter = getFilter({ onlyFiles: false });
+			const filter = getFilter(['**/*.md'], [], { onlyFiles: false });
 
 			const entry = tests.getFileEntry(false /** dot */);
 
-			const actual = filter.call(entry, ['**/*.md'], []);
+			const actual = filter(entry);
 
 			assert.ok(!actual);
 		});
 
 		it('should return false for file that excluded by negative patterns', () => {
-			const filter = getFilter({ onlyFiles: false });
+			const filter = getFilter(['**/*', '!**/*.txt'], ['**/*.txt'], { onlyFiles: false });
 
 			const entry = tests.getFileEntry(false /** dot */);
 
-			const actual = filter.call(entry, ['**/*', '!**/*.txt'], ['**/*.txt']);
+			const actual = filter(entry);
 
 			assert.ok(!actual);
 		});
 
 		it('should return true for directory that matched to patterns', () => {
-			const filter = getFilter({ onlyFiles: false });
+			const filter = getFilter(['**/directory/**'], [], { onlyFiles: false });
 
 			const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-			const actual = filter.call(entry, ['**/directory/**'], []);
+			const actual = filter(entry);
 
 			assert.ok(actual);
 		});
 
 		it('should return false for directory that not matched to patterns', () => {
-			const filter = getFilter({ onlyFiles: false });
+			const filter = getFilter(['**/super_directory/**'], [], { onlyFiles: false });
 
 			const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-			const actual = filter.call(entry, ['**/super_directory/**'], []);
+			const actual = filter(entry);
 
 			assert.ok(!actual);
 		});

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -2,6 +2,7 @@ import micromatch = require('micromatch');
 
 import { IOptions } from '../../managers/options';
 
+import { FilterFunction } from 'readdir-enhanced';
 import { IEntry } from '../../types/entries';
 import { Pattern } from '../../types/patterns';
 
@@ -11,9 +12,16 @@ export default class DeepFilter {
 	constructor(private readonly options: IOptions, private readonly micromatchOptions: micromatch.Options) { }
 
 	/**
+	 * Return filter for directories.
+	 */
+	public getFilter(positive: Pattern[], negative: Pattern[]): FilterFunction {
+		return (entry: IEntry) => this.filter(entry, positive, negative);
+	}
+
+	/**
 	 * Returns true if entry must be added to result.
 	 */
-	public call(entry: IEntry, patterns: Pattern[], negative: Pattern[]): boolean {
+	private filter(entry: IEntry, patterns: Pattern[], negative: Pattern[]): boolean {
 		// Exclude duplicate results
 		if (this.options.unique) {
 			if (this.isDuplicateEntry(entry)) {

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -42,8 +42,8 @@ export default abstract class Reader {
 	public getReaderOptions(task: ITask): IReaddirOptions {
 		return {
 			basePath: task.base === '.' ? '' : task.base,
-			filter: (entry) => this.entryFilter.call(entry, task.patterns, task.negative),
-			deep: (entry) => this.deepFilter.call(entry, task.negative, task.globstar),
+			filter: this.entryFilter.getFilter(task.positive, task.negative),
+			deep: this.deepFilter.getFilter(task.negative, task.globstar),
 			sep: '/'
 		};
 	}

--- a/src/types/patterns.ts
+++ b/src/types/patterns.ts
@@ -1,2 +1,3 @@
 export type Pattern = string;
+export type PatternRe = RegExp;
 export type PatternsGroup = Record<string, Pattern[]>;

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -1,0 +1,19 @@
+import * as assert from 'assert';
+
+import * as util from './path';
+
+describe('Utils → Path', () => {
+	describe('.isDotDirectory', () => {
+		it('should return true for dot directory', () => {
+			const actual = util.isDotDirectory('fixtures/.directory');
+
+			assert.ok(actual);
+		});
+
+		it('should return false for non-dot directory', () => {
+			const actual = util.isDotDirectory('fixtures/.directory/directory');
+
+			assert.ok(!actual);
+		});
+	});
+});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns true if the last partial of the path starting with a period.
+ */
+export function isDotDirectory(path: string): boolean {
+	const pathPartials = path.split('/');
+	const lastPathPartial: string = pathPartials[pathPartials.length - 1];
+
+	return lastPathPartial.startsWith('.');
+}

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -112,4 +112,57 @@ describe('Utils → Pattern', () => {
 			assert.ok(!actual);
 		});
 	});
+
+	describe('.makePatternRe', () => {
+		it('should return regexp for provided pattern', () => {
+			const expected: RegExp = /^(?:(?:(?:\.(?:\/|\\))(?=.))?(?!\/)(?!\.)(?=.)[^\/]*?\.js(?:(?:\/|\\)|$))$/;
+
+			const actual = util.makeRe('*.js', {});
+
+			assert.equal(actual.source, expected.source);
+		});
+	});
+
+	describe('.convertPatternsToRe', () => {
+		it('should return regexps for provided patterns', () => {
+			const expected: RegExp = /^(?:(?:(?:\.(?:\/|\\))(?=.))?(?!\/)(?!\.)(?=.)[^\/]*?\.js(?:(?:\/|\\)|$))$/;
+
+			const [actual] = util.convertPatternsToRe(['*.js'], {});
+
+			assert.equal(actual.source, expected.source);
+		});
+	});
+	describe('.matchAny', () => {
+		it('should return true', () => {
+			const actual = util.matchAny('fixtures/file.txt', [/fixture/, /fixtures\/file/]);
+
+			assert.ok(actual);
+		});
+
+		it('should return false', () => {
+			const actual = util.matchAny('fixtures/directory', [/fixtures\/file/]);
+
+			assert.ok(!actual);
+		});
+	});
+
+	describe('.match', () => {
+		it('should return false by negative patterns', () => {
+			const actual = util.match('fixtures/file.txt', [], [/fixtures\/file/]);
+
+			assert.ok(!actual);
+		});
+
+		it('should return false by positive patterns', () => {
+			const actual = util.match('fixtures/file.txt', [/fixtures\/file\.md/], []);
+
+			assert.ok(!actual);
+		});
+
+		it('should return true', () => {
+			const actual = util.match('fixtures/file.txt', [/fixtures\/file\.txt/], []);
+
+			assert.ok(actual);
+		});
+	});
 });

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -1,6 +1,7 @@
 import globParent = require('glob-parent');
+import micromatch = require('micromatch');
 
-import { Pattern } from '../types/patterns';
+import { Pattern, PatternRe } from '../types/patterns';
 
 /**
  * Returns negative pattern as positive pattern.
@@ -56,4 +57,38 @@ export function getBaseDirectory(pattern: Pattern): string {
  */
 export function hasGlobStar(pattern: Pattern): boolean {
 	return pattern.indexOf('**') !== -1;
+}
+
+/**
+ * Make RegExp for provided pattern.
+ */
+export function makeRe(pattern: Pattern, options: micromatch.Options): PatternRe {
+	return micromatch.makeRe(pattern, options);
+}
+
+/**
+ * Convert patterns to regexps.
+ */
+export function convertPatternsToRe(patterns: Pattern[], options: micromatch.Options): PatternRe[] {
+	return patterns.map((pattern) => makeRe(pattern, options));
+}
+
+/**
+ * Returns true if the entry match any of the given RegExp's.
+ */
+export function matchAny(entry: string, patternsRe: PatternRe[]): boolean {
+	for (const regexp of patternsRe) {
+		if (regexp.test(entry)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Returns true if the entry doesn't match any of the given negative RegExp's and match any of the given positive RegExp's.
+ */
+export function match(entry: string, positiveRe: PatternRe[], negativeRe: PatternRe[]): boolean {
+	return matchAny(entry, negativeRe) ? false : matchAny(entry, positiveRe);
 }


### PR DESCRIPTION
#### Links

  * #34

#### What is?

So we can make RegExp for each pattern once by micromatch and use them for further matching.  This makes the `fast-glob@2` faster then `fast-glob@1`.