### PR TITLE
ISSUE-39: Fix recursive reading for */ patterns

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -25,7 +25,7 @@ describe('Managers → Task', () => {
 			const expected: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: false,
+					recursive: false,
 					patterns: ['a/*.txt', 'a/*.md'],
 					positive: ['a/*.txt', 'a/*.md'],
 					negative: []
@@ -43,7 +43,7 @@ describe('Managers → Task', () => {
 			const expected: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: false,
+					recursive: false,
 					patterns: ['!a/*.txt', '!a/*.md'],
 					positive: [],
 					negative: ['a/*.txt', 'a/*.md']
@@ -61,7 +61,7 @@ describe('Managers → Task', () => {
 			const positive: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: true,
+					recursive: true,
 					patterns: ['a/**/*'],
 					positive: ['a/**/*'],
 					negative: []
@@ -71,7 +71,7 @@ describe('Managers → Task', () => {
 			const negative: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: false,
+					recursive: false,
 					patterns: ['!a/**/*.txt'],
 					positive: [],
 					negative: ['a/**/*.txt']
@@ -81,7 +81,7 @@ describe('Managers → Task', () => {
 			const expected: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: true,
+					recursive: true,
 					patterns: ['a/**/*', '!a/**/*.txt'],
 					positive: ['a/**/*'],
 					negative: ['a/**/*.txt']
@@ -98,7 +98,7 @@ describe('Managers → Task', () => {
 		it('should returns tasks', () => {
 			const expected: ITask[] = [{
 				base: 'a',
-				globstar: true,
+				recursive: true,
 				patterns: ['a/**/*', '!a/**/*.txt'],
 				positive: ['a/**/*'],
 				negative: ['a/**/*.txt']
@@ -124,7 +124,7 @@ describe('Managers → Task', () => {
 			it('should returns one global task', () => {
 				const expected: manager.ITask[] = [{
 					base: '.',
-					globstar: true,
+					recursive: true,
 					patterns: ['**/*'],
 					positive: ['**/*'],
 					negative: []
@@ -139,7 +139,7 @@ describe('Managers → Task', () => {
 			it('should returns one global task with negative patterns', () => {
 				const expected: manager.ITask[] = [{
 					base: '.',
-					globstar: true,
+					recursive: true,
 					patterns: ['**/*', '!**/*.md'],
 					positive: ['**/*'],
 					negative: ['**/*.md']
@@ -154,7 +154,7 @@ describe('Managers → Task', () => {
 			it('should returns one global task with negative patterns from options', () => {
 				const expected: manager.ITask[] = [{
 					base: '.',
-					globstar: true,
+					recursive: true,
 					patterns: ['**/*', '!**/*.md'],
 					positive: ['**/*'],
 					negative: ['**/*.md']
@@ -171,7 +171,7 @@ describe('Managers → Task', () => {
 			it('should returns one task', () => {
 				const expected: manager.ITask[] = [{
 					base: 'a',
-					globstar: true,
+					recursive: true,
 					patterns: ['a/**/*'],
 					positive: ['a/**/*'],
 					negative: []
@@ -186,7 +186,7 @@ describe('Managers → Task', () => {
 			it('should returns one task with negative patterns', () => {
 				const expected: manager.ITask[] = [{
 					base: 'a',
-					globstar: true,
+					recursive: true,
 					patterns: ['a/**/*', '!a/*.md'],
 					positive: ['a/**/*'],
 					negative: ['a/*.md']
@@ -201,7 +201,7 @@ describe('Managers → Task', () => {
 			it('should returns one task without unused negative patterns', () => {
 				const expected: manager.ITask[] = [{
 					base: 'a',
-					globstar: true,
+					recursive: true,
 					patterns: ['a/**/*'],
 					positive: ['a/**/*'],
 					negative: []
@@ -216,7 +216,7 @@ describe('Managers → Task', () => {
 			it('should returns one task with negative patterns from options', () => {
 				const expected: manager.ITask[] = [{
 					base: 'a',
-					globstar: true,
+					recursive: true,
 					patterns: ['a/**/*', '!a/*.md'],
 					positive: ['a/**/*'],
 					negative: ['a/*.md']
@@ -234,14 +234,14 @@ describe('Managers → Task', () => {
 				const expected: manager.ITask[] = [
 					{
 						base: 'a',
-						globstar: false,
+						recursive: false,
 						patterns: ['a/*', '!a/*.md'],
 						positive: ['a/*'],
 						negative: ['a/*.md']
 					},
 					{
 						base: 'b',
-						globstar: false,
+						recursive: false,
 						patterns: ['b/*'],
 						positive: ['b/*'],
 						negative: []
@@ -258,14 +258,14 @@ describe('Managers → Task', () => {
 				const expected: manager.ITask[] = [
 					{
 						base: 'a',
-						globstar: false,
+						recursive: false,
 						patterns: ['a/*', '!a/*.md', '!**/*.txt'],
 						positive: ['a/*'],
 						negative: ['a/*.md', '**/*.txt']
 					},
 					{
 						base: 'b',
-						globstar: false,
+						recursive: false,
 						patterns: ['b/*', '!**/*.txt'],
 						positive: ['b/*'],
 						negative: ['**/*.txt']
@@ -282,14 +282,14 @@ describe('Managers → Task', () => {
 				const expected: manager.ITask[] = [
 					{
 						base: 'a',
-						globstar: false,
+						recursive: false,
 						patterns: ['a/*', '!a/*.md', '!**/*.txt'],
 						positive: ['a/*'],
 						negative: ['a/*.md', '**/*.txt']
 					},
 					{
 						base: 'b',
-						globstar: false,
+						recursive: false,
 						patterns: ['b/*', '!**/*.txt'],
 						positive: ['b/*'],
 						negative: ['**/*.txt']

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -6,7 +6,7 @@ import { IOptions } from './options';
 
 export interface ITask {
 	base: string;
-	globstar: boolean;
+	recursive: boolean;
 	patterns: Pattern[];
 	positive: Pattern[];
 	negative: Pattern[];
@@ -40,7 +40,7 @@ export function makePositiveTaskGroup(positive: PatternsGroup): TaskGroup {
 
 		collection[base] = {
 			base,
-			globstar: positivePatterns.some(patternUtils.hasGlobStar),
+			recursive: positivePatterns.some(patternUtils.hasGlobStar),
 			patterns: positivePatterns,
 			positive: positivePatterns,
 			negative: []
@@ -59,7 +59,7 @@ export function makeNegativeTaskGroup(negative: PatternsGroup): TaskGroup {
 
 		collection[base] = {
 			base,
-			globstar: false, // Group of negative patterns is not an independent group (property is ignored)
+			recursive: false, // Group of negative patterns is not an independent group (property is ignored)
 			patterns: negativePatterns.map(patternUtils.convertToNegativePattern),
 			positive: [],
 			negative: negativePatterns
@@ -127,7 +127,7 @@ export function generate(patterns: Pattern[], options: IOptions): ITask[] {
 	if ('.' in positiveGroup) {
 		const task: ITask = {
 			base: '.',
-			globstar: positive.some(patternUtils.hasGlobStar),
+			recursive: positive.some(patternUtils.isDeep),
 			patterns: ([] as Pattern[]).concat(positive, negative.map(patternUtils.convertToNegativePattern)),
 			positive,
 			negative

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -40,7 +40,7 @@ export function makePositiveTaskGroup(positive: PatternsGroup): TaskGroup {
 
 		collection[base] = {
 			base,
-			recursive: positivePatterns.some(patternUtils.hasGlobStar),
+			recursive: positivePatterns.some(patternUtils.isRecursive),
 			patterns: positivePatterns,
 			positive: positivePatterns,
 			negative: []
@@ -127,7 +127,7 @@ export function generate(patterns: Pattern[], options: IOptions): ITask[] {
 	if ('.' in positiveGroup) {
 		const task: ITask = {
 			base: '.',
-			recursive: positive.some(patternUtils.isDeep),
+			recursive: positive.some(patternUtils.isRecursive),
 			patterns: ([] as Pattern[]).concat(positive, negative.map(patternUtils.convertToNegativePattern)),
 			positive,
 			negative

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -18,8 +18,8 @@ function getDeepFilterInstance(options?: IPartialOptions): DeepFilter {
 	});
 }
 
-function getFilter(patterns: Pattern[], globstar: boolean, options?: IPartialOptions): FilterFunction {
-	return getDeepFilterInstance(options).getFilter(patterns, globstar);
+function getFilter(patterns: Pattern[], recursive: boolean, options?: IPartialOptions): FilterFunction {
+	return getDeepFilterInstance(options).getFilter(patterns, recursive);
 }
 
 describe('Providers → Filters → Deep', () => {
@@ -34,7 +34,7 @@ describe('Providers → Filters → Deep', () => {
 	describe('.call', () => {
 		describe('Filter by «deep» option', () => {
 			it('should return false for nested directory when option is disabled', () => {
-				const filter = getFilter([], true /** globstar */, { deep: false });
+				const filter = getFilter([], true /** recursive */, { deep: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -44,7 +44,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false for nested directory when option has specified level', () => {
-				const filter = getFilter([], true /** globstar */, { deep: 2 });
+				const filter = getFilter([], true /** recursive */, { deep: 2 });
 
 				const entry = tests.getEntry({
 					path: 'fixtures/directory/directory',
@@ -60,7 +60,7 @@ describe('Providers → Filters → Deep', () => {
 
 		describe('Filter by «followSymlinkedDirectories» option', () => {
 			it('should return true for symlinked directory when option is enabled', () => {
-				const filter = getFilter([], true /** globstar */);
+				const filter = getFilter([], true /** recursive */);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, true /** isSymbolicLink */);
 
@@ -70,7 +70,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false for symlinked directory when option is disabled', () => {
-				const filter = getFilter([], true /** globstar */, { followSymlinkedDirectories: false });
+				const filter = getFilter([], true /** recursive */, { followSymlinkedDirectories: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, true /** isSymbolicLink */);
 
@@ -82,7 +82,7 @@ describe('Providers → Filters → Deep', () => {
 
 		describe('Filter by «dot» option', () => {
 			it('should return true for directory that starting with a period when option is enabled', () => {
-				const filter = getFilter([], true /** globstar */, { onlyFiles: false, dot: true });
+				const filter = getFilter([], true /** recursive */, { onlyFiles: false, dot: true });
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);
 
@@ -92,7 +92,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false for directory that starting with a period when option is disabled', () => {
-				const filter = getFilter([], true /** globstar */);
+				const filter = getFilter([], true /** recursive */);
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);
 
@@ -104,7 +104,7 @@ describe('Providers → Filters → Deep', () => {
 
 		describe('Filter by patterns', () => {
 			it('should return true for directory when negative patterns is not defined', () => {
-				const filter = getFilter([], true /** globstar */);
+				const filter = getFilter([], true /** recursive */);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -114,7 +114,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return true for directory that not matched to negative patterns', () => {
-				const filter = getFilter(['**/pony/**'], true /** globstar */);
+				const filter = getFilter(['**/pony/**'], true /** recursive */);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -123,8 +123,8 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(actual);
 			});
 
-			it('should return true for directory when negative patterns has globstar after directory name', () => {
-				const filter = getFilter(['**/directory/**'], true /** globstar */);
+			it('should return true for directory when negative patterns has recursive after directory name', () => {
+				const filter = getFilter(['**/directory/**'], true /** recursive */);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -134,7 +134,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false for directory that matched to negative patterns', () => {
-				const filter = getFilter(['**/directory'], true /** globstar */);
+				const filter = getFilter(['**/directory'], true /** recursive */);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -144,9 +144,9 @@ describe('Providers → Filters → Deep', () => {
 			});
 		});
 
-		describe('Filter by «globstar» parameter', () => {
-			it('should return true by globstar parameter', () => {
-				const filter = getFilter([], true /** globstar */);
+		describe('Filter by «recursive» parameter', () => {
+			it('should return true by recursive parameter', () => {
+				const filter = getFilter([], true /** recursive */);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -155,8 +155,8 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(actual);
 			});
 
-			it('should return false by globstar parameter', () => {
-				const filter = getFilter([], false /** globstar */);
+			it('should return false by recursive parameter', () => {
+				const filter = getFilter([], false /** recursive */);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -15,16 +15,16 @@ export default class DeepFilter {
 	/**
 	 * Returns filter for directories.
 	 */
-	public getFilter(negative: Pattern[], globstar: boolean): FilterFunction {
+	public getFilter(negative: Pattern[], recursive: boolean): FilterFunction {
 		const negativeRe: PatternRe[] = patternUtils.convertPatternsToRe(negative, this.micromatchOptions);
 
-		return (entry: IEntry) => this.filter(entry, negativeRe, globstar);
+		return (entry: IEntry) => this.filter(entry, negativeRe, recursive);
 	}
 
 	/**
 	 * Returns true if directory must be read.
 	 */
-	private filter(entry: IEntry, negativeRe: PatternRe[], globstar: boolean): boolean {
+	private filter(entry: IEntry, negativeRe: PatternRe[], recursive: boolean): boolean {
 		if (!this.options.deep) {
 			return false;
 		}
@@ -50,7 +50,7 @@ export default class DeepFilter {
 			return false;
 		}
 
-		return globstar;
+		return recursive;
 	}
 
 	/**

--- a/src/providers/reader-async.spec.ts
+++ b/src/providers/reader-async.spec.ts
@@ -46,7 +46,7 @@ describe('Providers → ReaderAsync', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
-			globstar: true,
+			recursive: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader-stream.spec.ts
+++ b/src/providers/reader-stream.spec.ts
@@ -64,7 +64,7 @@ describe('Providers → ReaderStream', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
-			globstar: true,
+			recursive: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader-sync.spec.ts
+++ b/src/providers/reader-sync.spec.ts
@@ -41,7 +41,7 @@ describe('Providers → ReaderSync', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
-			globstar: true,
+			recursive: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader.spec.ts
+++ b/src/providers/reader.spec.ts
@@ -59,7 +59,7 @@ describe('Providers → Reader', () => {
 
 			const actual = reader.getReaderOptions({
 				base: '.',
-				globstar: true,
+				recursive: true,
 				patterns: ['**/*'],
 				positive: ['**/*'],
 				negative: []
@@ -76,7 +76,7 @@ describe('Providers → Reader', () => {
 
 			const actual = reader.getReaderOptions({
 				base: 'fixtures',
-				globstar: true,
+				recursive: true,
 				patterns: ['**/*'],
 				positive: ['**/*'],
 				negative: []

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -43,7 +43,7 @@ export default abstract class Reader {
 		return {
 			basePath: task.base === '.' ? '' : task.base,
 			filter: this.entryFilter.getFilter(task.positive, task.negative),
-			deep: this.deepFilter.getFilter(task.negative, task.globstar),
+			deep: this.deepFilter.getFilter(task.negative, task.recursive),
 			sep: '/'
 		};
 	}

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -99,15 +99,21 @@ describe('Utils → Pattern', () => {
 		});
 	});
 
-	describe('.hasGlobStar', () => {
-		it('should returns true', () => {
-			const actual = util.hasGlobStar('**/*.js');
+	describe('.isRecursive', () => {
+		it('should returns true for globstar', () => {
+			const actual = util.isRecursive('**/*.js');
+
+			assert.ok(actual);
+		});
+
+		it('should returns true for star with slash', () => {
+			const actual = util.isRecursive('*/*.js');
 
 			assert.ok(actual);
 		});
 
 		it('should returns false', () => {
-			const actual = util.hasGlobStar('*.js');
+			const actual = util.isRecursive('*.js');
 
 			assert.ok(!actual);
 		});

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -55,8 +55,8 @@ export function getBaseDirectory(pattern: Pattern): string {
 /**
  * Return true if provided pattern has globstar.
  */
-export function hasGlobStar(pattern: Pattern): boolean {
-	return pattern.indexOf('**') !== -1;
+export function isRecursive(pattern: Pattern): boolean {
+	return pattern.indexOf('**') !== -1 || pattern.indexOf('*/') !== -1;
 }
 
 /**


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a potential fix for #39.

### What changes did you make? (Give an overview)

0. Rename `globstar` property to `recursive` for `ITask` interface.
1. Deeply reading for patterns that have a star with slash (`*/`)