### PR TITLE
ISSUE-39: Fix deeply reading

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -25,7 +25,6 @@ describe('Managers → Task', () => {
 			const expected: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: false,
 					patterns: ['a/*.txt', 'a/*.md'],
 					positive: ['a/*.txt', 'a/*.md'],
 					negative: []
@@ -43,7 +42,6 @@ describe('Managers → Task', () => {
 			const expected: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: false,
 					patterns: ['!a/*.txt', '!a/*.md'],
 					positive: [],
 					negative: ['a/*.txt', 'a/*.md']
@@ -61,7 +59,6 @@ describe('Managers → Task', () => {
 			const positive: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: true,
 					patterns: ['a/**/*'],
 					positive: ['a/**/*'],
 					negative: []
@@ -71,7 +68,6 @@ describe('Managers → Task', () => {
 			const negative: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: false,
 					patterns: ['!a/**/*.txt'],
 					positive: [],
 					negative: ['a/**/*.txt']
@@ -81,7 +77,6 @@ describe('Managers → Task', () => {
 			const expected: TaskGroup = {
 				a: {
 					base: 'a',
-					globstar: true,
 					patterns: ['a/**/*', '!a/**/*.txt'],
 					positive: ['a/**/*'],
 					negative: ['a/**/*.txt']
@@ -98,7 +93,6 @@ describe('Managers → Task', () => {
 		it('should returns tasks', () => {
 			const expected: ITask[] = [{
 				base: 'a',
-				globstar: true,
 				patterns: ['a/**/*', '!a/**/*.txt'],
 				positive: ['a/**/*'],
 				negative: ['a/**/*.txt']
@@ -124,7 +118,6 @@ describe('Managers → Task', () => {
 			it('should returns one global task', () => {
 				const expected: manager.ITask[] = [{
 					base: '.',
-					globstar: true,
 					patterns: ['**/*'],
 					positive: ['**/*'],
 					negative: []
@@ -139,7 +132,6 @@ describe('Managers → Task', () => {
 			it('should returns one global task with negative patterns', () => {
 				const expected: manager.ITask[] = [{
 					base: '.',
-					globstar: true,
 					patterns: ['**/*', '!**/*.md'],
 					positive: ['**/*'],
 					negative: ['**/*.md']
@@ -154,7 +146,6 @@ describe('Managers → Task', () => {
 			it('should returns one global task with negative patterns from options', () => {
 				const expected: manager.ITask[] = [{
 					base: '.',
-					globstar: true,
 					patterns: ['**/*', '!**/*.md'],
 					positive: ['**/*'],
 					negative: ['**/*.md']
@@ -171,7 +162,6 @@ describe('Managers → Task', () => {
 			it('should returns one task', () => {
 				const expected: manager.ITask[] = [{
 					base: 'a',
-					globstar: true,
 					patterns: ['a/**/*'],
 					positive: ['a/**/*'],
 					negative: []
@@ -186,7 +176,6 @@ describe('Managers → Task', () => {
 			it('should returns one task with negative patterns', () => {
 				const expected: manager.ITask[] = [{
 					base: 'a',
-					globstar: true,
 					patterns: ['a/**/*', '!a/*.md'],
 					positive: ['a/**/*'],
 					negative: ['a/*.md']
@@ -201,7 +190,6 @@ describe('Managers → Task', () => {
 			it('should returns one task without unused negative patterns', () => {
 				const expected: manager.ITask[] = [{
 					base: 'a',
-					globstar: true,
 					patterns: ['a/**/*'],
 					positive: ['a/**/*'],
 					negative: []
@@ -216,7 +204,6 @@ describe('Managers → Task', () => {
 			it('should returns one task with negative patterns from options', () => {
 				const expected: manager.ITask[] = [{
 					base: 'a',
-					globstar: true,
 					patterns: ['a/**/*', '!a/*.md'],
 					positive: ['a/**/*'],
 					negative: ['a/*.md']
@@ -234,14 +221,14 @@ describe('Managers → Task', () => {
 				const expected: manager.ITask[] = [
 					{
 						base: 'a',
-						globstar: false,
+
 						patterns: ['a/*', '!a/*.md'],
 						positive: ['a/*'],
 						negative: ['a/*.md']
 					},
 					{
 						base: 'b',
-						globstar: false,
+
 						patterns: ['b/*'],
 						positive: ['b/*'],
 						negative: []
@@ -258,14 +245,14 @@ describe('Managers → Task', () => {
 				const expected: manager.ITask[] = [
 					{
 						base: 'a',
-						globstar: false,
+
 						patterns: ['a/*', '!a/*.md', '!**/*.txt'],
 						positive: ['a/*'],
 						negative: ['a/*.md', '**/*.txt']
 					},
 					{
 						base: 'b',
-						globstar: false,
+
 						patterns: ['b/*', '!**/*.txt'],
 						positive: ['b/*'],
 						negative: ['**/*.txt']
@@ -282,14 +269,14 @@ describe('Managers → Task', () => {
 				const expected: manager.ITask[] = [
 					{
 						base: 'a',
-						globstar: false,
+
 						patterns: ['a/*', '!a/*.md', '!**/*.txt'],
 						positive: ['a/*'],
 						negative: ['a/*.md', '**/*.txt']
 					},
 					{
 						base: 'b',
-						globstar: false,
+
 						patterns: ['b/*', '!**/*.txt'],
 						positive: ['b/*'],
 						negative: ['**/*.txt']

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -6,7 +6,6 @@ import { IOptions } from './options';
 
 export interface ITask {
 	base: string;
-	globstar: boolean;
 	patterns: Pattern[];
 	positive: Pattern[];
 	negative: Pattern[];
@@ -40,7 +39,6 @@ export function makePositiveTaskGroup(positive: PatternsGroup): TaskGroup {
 
 		collection[base] = {
 			base,
-			globstar: positivePatterns.some(patternUtils.hasGlobStar),
 			patterns: positivePatterns,
 			positive: positivePatterns,
 			negative: []
@@ -59,7 +57,6 @@ export function makeNegativeTaskGroup(negative: PatternsGroup): TaskGroup {
 
 		collection[base] = {
 			base,
-			globstar: false, // Group of negative patterns is not an independent group (property is ignored)
 			patterns: negativePatterns.map(patternUtils.convertToNegativePattern),
 			positive: [],
 			negative: negativePatterns
@@ -127,7 +124,6 @@ export function generate(patterns: Pattern[], options: IOptions): ITask[] {
 	if ('.' in positiveGroup) {
 		const task: ITask = {
 			base: '.',
-			globstar: positive.some(patternUtils.hasGlobStar),
 			patterns: ([] as Pattern[]).concat(positive, negative.map(patternUtils.convertToNegativePattern)),
 			positive,
 			negative

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -18,8 +18,8 @@ function getDeepFilterInstance(options?: IPartialOptions): DeepFilter {
 	});
 }
 
-function getFilter(positive: Pattern[], negative: Pattern[], globstar: boolean, options?: IPartialOptions): FilterFunction {
-	return getDeepFilterInstance(options).getFilter(positive, negative, globstar);
+function getFilter(positive: Pattern[], negative: Pattern[], options?: IPartialOptions): FilterFunction {
+	return getDeepFilterInstance(options).getFilter(positive, negative);
 }
 
 describe('Providers → Filters → Deep', () => {
@@ -34,7 +34,7 @@ describe('Providers → Filters → Deep', () => {
 	describe('.call', () => {
 		describe('Filter by «deep» option', () => {
 			it('should return false for nested directory when option is disabled', () => {
-				const filter = getFilter([], [], true /** globstar */, { deep: false });
+				const filter = getFilter(['**/*'], [], { deep: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -44,7 +44,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false for nested directory when option has specified level', () => {
-				const filter = getFilter([], [], true /** globstar */, { deep: 2 });
+				const filter = getFilter(['**/*'], [], { deep: 2 });
 
 				const entry = tests.getEntry({
 					path: 'fixtures/directory/directory',
@@ -60,7 +60,7 @@ describe('Providers → Filters → Deep', () => {
 
 		describe('Filter by «followSymlinkedDirectories» option', () => {
 			it('should return true for symlinked directory when option is enabled', () => {
-				const filter = getFilter([], [], true /** globstar */);
+				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, true /** isSymbolicLink */);
 
@@ -70,7 +70,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false for symlinked directory when option is disabled', () => {
-				const filter = getFilter([], [], true /** globstar */, { followSymlinkedDirectories: false });
+				const filter = getFilter(['**/*'], [], { followSymlinkedDirectories: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, true /** isSymbolicLink */);
 
@@ -82,7 +82,7 @@ describe('Providers → Filters → Deep', () => {
 
 		describe('Filter by «dot» option', () => {
 			it('should return true for directory that starting with a period when option is enabled', () => {
-				const filter = getFilter([], [], true /** globstar */, { onlyFiles: false, dot: true });
+				const filter = getFilter(['**/*'], [], { onlyFiles: false, dot: true });
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);
 
@@ -92,7 +92,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false for directory that starting with a period when option is disabled', () => {
-				const filter = getFilter([], [], true /** globstar */);
+				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);
 
@@ -104,7 +104,7 @@ describe('Providers → Filters → Deep', () => {
 
 		describe('Filter by patterns', () => {
 			it('should return true for directory when negative patterns is not defined', () => {
-				const filter = getFilter([], [], true /** globstar */);
+				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -114,7 +114,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return true for directory that not matched to negative patterns', () => {
-				const filter = getFilter([], ['**/pony/**'], true /** globstar */);
+				const filter = getFilter(['**/*'], ['**/pony/**']);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -124,7 +124,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return true for directory when negative patterns has globstar after directory name', () => {
-				const filter = getFilter([], ['**/directory/**'], true /** globstar */);
+				const filter = getFilter(['**/*'], ['**/directory/**']);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -134,7 +134,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false for directory that matched to negative patterns', () => {
-				const filter = getFilter([], ['**/directory'], true /** globstar */);
+				const filter = getFilter([], ['**/directory']);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -146,7 +146,7 @@ describe('Providers → Filters → Deep', () => {
 
 		describe('Filter by «depth» parameter', () => {
 			it('should return true if the patterns have a globstar', () => {
-				const filter = getFilter(['**/*'], [], true /** globstar */);
+				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -156,7 +156,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return true if the patterns have a depth greater than the entry', () => {
-				const filter = getFilter(['fixtures/*/*'], [], false /** globstar */);
+				const filter = getFilter(['fixtures/*/*'], []);
 
 				const entry = tests.getEntry({
 					path: 'fixtures/directory/directory',
@@ -170,7 +170,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return false if the patterns have a depth smaller than the entry', () => {
-				const filter = getFilter(['fixtures/*'], [], false /** globstar */);
+				const filter = getFilter(['fixtures/*'], []);
 
 				const entry = tests.getEntry({
 					path: 'fixtures/directory/directory',

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -1,5 +1,6 @@
 import micromatch = require('micromatch');
 
+import * as arrayUtils from '../../utils/array';
 import * as pathUtils from '../../utils/path';
 import * as patternUtils from '../../utils/pattern';
 
@@ -15,25 +16,21 @@ export default class DeepFilter {
 	/**
 	 * Returns filter for directories.
 	 */
-	public getFilter(negative: Pattern[], globstar: boolean): FilterFunction {
+	public getFilter(positive: Pattern[], negative: Pattern[], globstar: boolean): FilterFunction {
+		const depth = this.getMaxDeth(positive, globstar);
+
 		const negativeRe: PatternRe[] = patternUtils.convertPatternsToRe(negative, this.micromatchOptions);
 
-		return (entry: IEntry) => this.filter(entry, negativeRe, globstar);
+		return (entry: IEntry) => this.filter(entry, negativeRe, depth);
 	}
 
 	/**
 	 * Returns true if directory must be read.
 	 */
-	private filter(entry: IEntry, negativeRe: PatternRe[], globstar: boolean): boolean {
-		if (!this.options.deep) {
-			return false;
-		}
-
+	private filter(entry: IEntry, negativeRe: PatternRe[], depth: number): boolean {
 		// Skip reading, depending on the nesting level
-		if (typeof this.options.deep === 'number') {
-			if (entry.depth > this.options.deep) {
-				return false;
-			}
+		if (!this.options.deep || this.skipByDeepOption(entry) || this.skipByPatternDepth(entry, depth)) {
+			return false;
 		}
 
 		// Skip reading if the directory is symlink and we don't want expand symlinks
@@ -46,11 +43,21 @@ export default class DeepFilter {
 			return false;
 		}
 
+		// Skip by negative patterns
 		if (patternUtils.matchAny(entry.path, negativeRe)) {
 			return false;
 		}
 
-		return globstar;
+		return true;
+	}
+
+	/**
+	 * Returns max depth for reading.
+	 */
+	private getMaxDeth(positive: Pattern[], globstar: boolean): number {
+		const positiveDepths = positive.map(patternUtils.getDepth);
+
+		return globstar ? Infinity : arrayUtils.max(positiveDepths);
 	}
 
 	/**
@@ -65,5 +72,19 @@ export default class DeepFilter {
 	 */
 	private isFollowedSymlink(entry: IEntry): boolean {
 		return !this.options.followSymlinkedDirectories && entry.isSymbolicLink();
+	}
+
+	/**
+	 * Returns true when the «deep» options is number and entry depth greater that the option value.
+	 */
+	private skipByDeepOption(entry: IEntry): boolean {
+		return typeof this.options.deep === 'number' && entry.depth > this.options.deep;
+	}
+
+	/**
+	 * Return true when depth parameter is not an Infinity and entry depth greater that the parameter value.
+	 */
+	private skipByPatternDepth(entry: IEntry, depth: number): boolean {
+		return depth !== Infinity && entry.depth > depth;
 	}
 }

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -16,9 +16,8 @@ export default class DeepFilter {
 	/**
 	 * Returns filter for directories.
 	 */
-	public getFilter(positive: Pattern[], negative: Pattern[], globstar: boolean): FilterFunction {
-		const depth = this.getMaxDeth(positive, globstar);
-
+	public getFilter(positive: Pattern[], negative: Pattern[]): FilterFunction {
+		const depth = this.getMaxDeth(positive);
 		const negativeRe: PatternRe[] = patternUtils.convertPatternsToRe(negative, this.micromatchOptions);
 
 		return (entry: IEntry) => this.filter(entry, negativeRe, depth);
@@ -54,10 +53,11 @@ export default class DeepFilter {
 	/**
 	 * Returns max depth for reading.
 	 */
-	private getMaxDeth(positive: Pattern[], globstar: boolean): number {
-		const positiveDepths = positive.map(patternUtils.getDepth);
+	private getMaxDeth(positive: Pattern[]): number {
+		const globstar = positive.some(patternUtils.hasGlobStar);
+		const patternDepths = positive.map(patternUtils.getDepth);
 
-		return globstar ? Infinity : arrayUtils.max(positiveDepths);
+		return globstar ? Infinity : arrayUtils.max(patternDepths);
 	}
 
 	/**

--- a/src/providers/reader-async.spec.ts
+++ b/src/providers/reader-async.spec.ts
@@ -46,7 +46,6 @@ describe('Providers → ReaderAsync', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
-			globstar: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader-stream.spec.ts
+++ b/src/providers/reader-stream.spec.ts
@@ -64,7 +64,6 @@ describe('Providers → ReaderStream', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
-			globstar: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader-sync.spec.ts
+++ b/src/providers/reader-sync.spec.ts
@@ -41,7 +41,6 @@ describe('Providers → ReaderSync', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
-			globstar: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader.spec.ts
+++ b/src/providers/reader.spec.ts
@@ -59,7 +59,6 @@ describe('Providers → Reader', () => {
 
 			const actual = reader.getReaderOptions({
 				base: '.',
-				globstar: true,
 				patterns: ['**/*'],
 				positive: ['**/*'],
 				negative: []
@@ -76,7 +75,6 @@ describe('Providers → Reader', () => {
 
 			const actual = reader.getReaderOptions({
 				base: 'fixtures',
-				globstar: true,
 				patterns: ['**/*'],
 				positive: ['**/*'],
 				negative: []

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -43,7 +43,7 @@ export default abstract class Reader {
 		return {
 			basePath: task.base === '.' ? '' : task.base,
 			filter: this.entryFilter.getFilter(task.positive, task.negative),
-			deep: this.deepFilter.getFilter(task.positive, task.negative, task.globstar),
+			deep: this.deepFilter.getFilter(task.positive, task.negative),
 			sep: '/'
 		};
 	}

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -43,7 +43,7 @@ export default abstract class Reader {
 		return {
 			basePath: task.base === '.' ? '' : task.base,
 			filter: this.entryFilter.getFilter(task.positive, task.negative),
-			deep: this.deepFilter.getFilter(task.negative, task.globstar),
+			deep: this.deepFilter.getFilter(task.positive, task.negative, task.globstar),
 			sep: '/'
 		};
 	}

--- a/src/utils/array.spec.ts
+++ b/src/utils/array.spec.ts
@@ -12,4 +12,14 @@ describe('Utils → Array', () => {
 			assert.deepEqual(actual, expected);
 		});
 	});
+
+	describe('.max', () => {
+		it('should return max element of array', () => {
+			const expected: number = 3;
+
+			const actual = util.max([0, 3, 1]);
+
+			assert.equal(actual, expected);
+		});
+	});
 });

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -4,3 +4,10 @@
 export function flatten<T>(items: T[][]): T[] {
 	return items.reduce((collection, item) => ([] as T[]).concat(collection, item), [] as T[]);
 }
+
+/**
+ * Returns max number from array.
+ */
+export function max(items: Array<{}>): number {
+	return Math.max.apply(null, items);
+}

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -113,6 +113,16 @@ describe('Utils → Pattern', () => {
 		});
 	});
 
+	describe('.getDepth', () => {
+		it('should returns 3', () => {
+			const expected: number = 4;
+
+			const actual = util.getDepth('a/b/*/*.js');
+
+			assert.equal(actual, expected);
+		});
+	});
+
 	describe('.makePatternRe', () => {
 		it('should return regexp for provided pattern', () => {
 			const expected: RegExp = /^(?:(?:(?:\.(?:\/|\\))(?=.))?(?!\/)(?!\.)(?=.)[^\/]*?\.js(?:(?:\/|\\)|$))$/;

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -60,6 +60,13 @@ export function hasGlobStar(pattern: Pattern): boolean {
 }
 
 /**
+ * Return naive depth of provided pattern.
+ */
+export function getDepth(pattern: Pattern): number {
+	return pattern.split('/').length;
+}
+
+/**
  * Make RegExp for provided pattern.
  */
 export function makeRe(pattern: Pattern, options: micromatch.Options): PatternRe {


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a potential fix for #39.

### What changes did you make? (Give an overview)

0. By default `deep` filter returns true.
1. Compute maximum depth of patterns to exclude a deeper directory (`**` === `Infinity`).
2. Delete the `globstar` property from `ITask` interface.