### PR TITLE
ISSUE-42: RangeError: Maximum call stack size exceeded

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "glob-parent": "3.1.0",
     "merge2": "1.2.1",
     "micromatch": "3.1.5",
-    "readdir-enhanced": "2.2.0"
+    "readdir-enhanced": "mrmlnc/readdir-enhanced#ISSUE-11_monkey_fix"
   },
   "scripts": {
     "clean": "rimraf out",


### PR DESCRIPTION
### Links

  * #42 
  * #48 

### What is the purpose of this pull request?

Fix `RangeError: Maximum call stack size exceeded` for synchronous mode with large directories.

### What changes did you make? (Give an overview)

Temporary switch to fork branch. A thorough solution will be found in https://github.com/BigstickCarpet/readdir-enhanced/issues/11.

### Check list

  * [x] Run benchmark