### PR TITLE
TRIVIAL: Fix problem when onlyFiles & onlyDirectories options is enabled

### DIFF
--- a/src/managers/options.spec.ts
+++ b/src/managers/options.spec.ts
@@ -2,56 +2,53 @@ import * as assert from 'assert';
 
 import * as manager from './options';
 
+function getOptions(options?: manager.IPartialOptions): manager.IOptions {
+	return Object.assign<manager.IOptions, manager.IPartialOptions | undefined>({
+		cwd: process.cwd(),
+		deep: true,
+		ignore: [],
+		dot: false,
+		stats: false,
+		onlyFiles: true,
+		onlyDirectories: false,
+		followSymlinkedDirectories: true,
+		unique: true,
+		markDirectories: false,
+		absolute: false,
+		nobrace: false,
+		noglobstar: false,
+		noext: false,
+		nocase: false,
+		matchBase: false,
+		transform: null
+	}, options);
+}
+
 describe('Managers → Options', () => {
-	describe('.build', () => {
-		it('should returns builded options for empty object', () => {
-			const expected: manager.IOptions = {
-				cwd: process.cwd(),
-				deep: true,
-				ignore: [],
-				dot: false,
-				stats: false,
-				onlyFiles: true,
-				onlyDirectories: false,
-				followSymlinkedDirectories: true,
-				unique: true,
-				markDirectories: false,
-				absolute: false,
-				nobrace: false,
-				noglobstar: false,
-				noext: false,
-				nocase: false,
-				matchBase: false,
-				transform: null
-			};
+	describe('.prepare', () => {
+		it('should returns prepared options for empty object', () => {
+			const expected: manager.IOptions = getOptions();
 
 			const actual = manager.prepare();
 
 			assert.deepEqual(actual, expected);
 		});
 
-		it('should returns builded options for provided object', () => {
-			const expected: manager.IOptions = {
-				cwd: process.cwd(),
-				deep: true,
-				ignore: [],
-				dot: false,
-				stats: true,
-				onlyFiles: true,
-				onlyDirectories: false,
-				followSymlinkedDirectories: true,
-				unique: true,
-				markDirectories: false,
-				absolute: false,
-				nobrace: false,
-				noglobstar: false,
-				noext: false,
-				nocase: false,
-				matchBase: false,
-				transform: null
-			};
+		it('should returns prepared options for provided object', () => {
+			const expected: manager.IOptions = getOptions({ stats: true });
 
 			const actual = manager.prepare({ stats: true });
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should disable the «onlyFiles» option if «onlyDirectories» option is enabled', () => {
+			const expected: manager.IOptions = getOptions({
+				onlyFiles: false,
+				onlyDirectories: true
+			});
+
+			const actual = manager.prepare({ onlyDirectories: true });
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/managers/options.ts
+++ b/src/managers/options.ts
@@ -80,7 +80,7 @@ export interface IOptions<T = EntryItem> {
 export type IPartialOptions<T = EntryItem> = Partial<IOptions<T>>;
 
 export function prepare(options?: IPartialOptions): IOptions {
-	return Object.assign<IOptions, IPartialOptions | undefined>({
+	const opts = Object.assign<IOptions, IPartialOptions | undefined>({
 		cwd: process.cwd(),
 		deep: true,
 		ignore: [],
@@ -99,4 +99,10 @@ export function prepare(options?: IPartialOptions): IOptions {
 		matchBase: false,
 		transform: null
 	}, options);
+
+	if (opts.onlyDirectories) {
+		opts.onlyFiles = false;
+	}
+
+	return opts;
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix problem when `onlyFiles` option and `onlyDirectories` is enabled in the one time. In this case will be work only the `onlyFiles` option.

### What changes did you make? (Give an overview)
…