### PR TITLE
GLOBBY-70: Convert backslashes to forward slashes in the patterns

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -129,6 +129,20 @@ describe('Managers → Task', () => {
 				assert.deepEqual(actual, expected);
 			});
 
+			it('should returns one global task with converted slashes in the patterns', () => {
+				const expected: manager.ITask[] = [{
+					base: '.',
+					patterns: ['**/*'],
+					positive: ['**/*'],
+					negative: []
+				}];
+
+				const options = optionsManager.prepare({ ignore: [] });
+				const actual = manager.generate(['**\\*'], options);
+
+				assert.deepEqual(actual, expected);
+			});
+
 			it('should returns one global task with negative patterns', () => {
 				const expected: manager.ITask[] = [{
 					base: '.',

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -109,13 +109,15 @@ export function makeTasks(positive: PatternsGroup, negative: PatternsGroup): ITa
  * Generate tasks for provided patterns based on base directory of each pattern.
  */
 export function generate(patterns: Pattern[], options: IOptions): ITask[] {
-	const positive: Pattern[] = patternUtils.getPositivePatterns(patterns);
+	const unixPatterns = patterns.map(patternUtils.unixifyPattern);
+
+	const positive: Pattern[] = patternUtils.getPositivePatterns(unixPatterns);
 	if (positive.length === 0) {
 		return [];
 	}
 
 	const ignore: Pattern[] = options.ignore;
-	const negative: Pattern[] = patternUtils.getNegativePatterns(patterns)
+	const negative: Pattern[] = patternUtils.getNegativePatterns(unixPatterns)
 		.map(patternUtils.convertToPositivePattern)
 		.concat(ignore)
 		.map(patternUtils.trimTrailingSlashGlobStar);

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -5,6 +5,16 @@ import * as util from './pattern';
 import { Pattern } from '../types/patterns';
 
 describe('Utils → Pattern', () => {
+	describe('.unixifyPattern', () => {
+		it('should convert backslashes to forward slashes', () => {
+			const expected: Pattern = '**/*';
+
+			const actual = util.unixifyPattern('**\\*');
+
+			assert.equal(actual, expected);
+		});
+	});
+
 	describe('.convertToPositivePattern', () => {
 		it('should returns converted positive pattern', () => {
 			const expected: Pattern = '*.js';

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -6,6 +6,13 @@ import { Pattern, PatternRe } from '../types/patterns';
 const GLOBSTAR = '**';
 
 /**
+ * Convert a windows «path» to a unix-style «path».
+ */
+export function unixifyPattern(pattern: Pattern): Pattern {
+	return pattern.replace(/\\/g, '/');
+}
+
+/**
  * Returns negative pattern as positive pattern.
  */
 export function convertToPositivePattern(pattern: Pattern): Pattern {


### PR DESCRIPTION
### What is the purpose of this pull request?
This is fix for https://github.com/sindresorhus/globby/issues/70 when globby is broken in the Windows machine.

### What changes did you make? (Give an overview)
Convert backslashes to forward slashes in the patterns.