### PR TITLE
GLOBBY-72: Use «readdir-enhanced» from my own namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^2.2.48",
     "@types/node": "^9.4.0",
-    "@types/readdir-enhanced": "^2.2.0",
     "@types/rimraf": "2.0.2",
     "bash-glob": "^2.0.0",
     "compute-stdev": "^1.0.0",
@@ -48,10 +47,10 @@
     "typescript": "^2.7.1"
   },
   "dependencies": {
+    "@mrmlnc/readdir-enhanced": "^2.2.1",
     "glob-parent": "3.1.0",
     "merge2": "1.2.1",
-    "micromatch": "3.1.5",
-    "readdir-enhanced": "mrmlnc/readdir-enhanced#ISSUE-11_monkey_fix"
+    "micromatch": "3.1.5"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -6,7 +6,7 @@ import DeepFilter from './deep';
 
 import * as optionsManager from '../../managers/options';
 
-import { FilterFunction } from 'readdir-enhanced';
+import { FilterFunction } from '@mrmlnc/readdir-enhanced';
 import { IOptions, IPartialOptions } from '../../managers/options';
 import { Pattern } from '../../types/patterns';
 

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -6,7 +6,7 @@ import * as patternUtils from '../../utils/pattern';
 
 import { IOptions } from '../../managers/options';
 
-import { FilterFunction } from 'readdir-enhanced';
+import { FilterFunction } from '@mrmlnc/readdir-enhanced';
 import { IEntry } from '../../types/entries';
 import { Pattern, PatternRe } from '../../types/patterns';
 

--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -6,7 +6,7 @@ import EntryFilter from './entry';
 
 import * as optionsManager from '../../managers/options';
 
-import { FilterFunction } from 'readdir-enhanced';
+import { FilterFunction } from '@mrmlnc/readdir-enhanced';
 import { IOptions, IPartialOptions } from '../../managers/options';
 import { Pattern } from '../../types/patterns';
 

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -4,7 +4,7 @@ import * as patternUtils from '../../utils/pattern';
 
 import { IOptions } from '../../managers/options';
 
-import { FilterFunction } from 'readdir-enhanced';
+import { FilterFunction } from '@mrmlnc/readdir-enhanced';
 import { IEntry } from '../../types/entries';
 import { Pattern, PatternRe } from '../../types/patterns';
 

--- a/src/providers/reader-async.ts
+++ b/src/providers/reader-async.ts
@@ -1,4 +1,4 @@
-import * as readdir from 'readdir-enhanced';
+import * as readdir from '@mrmlnc/readdir-enhanced';
 
 import Reader from './reader';
 

--- a/src/providers/reader-stream.ts
+++ b/src/providers/reader-stream.ts
@@ -1,6 +1,6 @@
 import * as stream from 'stream';
 
-import * as readdir from 'readdir-enhanced';
+import * as readdir from '@mrmlnc/readdir-enhanced';
 
 import Reader from './reader';
 

--- a/src/providers/reader-sync.ts
+++ b/src/providers/reader-sync.ts
@@ -1,4 +1,4 @@
-import * as readdir from 'readdir-enhanced';
+import * as readdir from '@mrmlnc/readdir-enhanced';
 
 import Reader from './reader';
 

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -8,7 +8,7 @@ import EntryFilter from './filters/entry';
 import { IOptions } from '../managers/options';
 import { ITask } from '../managers/tasks';
 
-import { Options as IReaddirOptions } from 'readdir-enhanced';
+import { Options as IReaddirOptions } from '@mrmlnc/readdir-enhanced';
 import { Entry, EntryItem } from '../types/entries';
 
 export default abstract class Reader {


### PR DESCRIPTION
### What is the purpose of this pull request?
This is a fix for https://github.com/sindresorhus/globby/issues/72 when globby needs git executable on install.

### What changes did you make? (Give an overview)
Use `readdir-enhanced` package from my own namespace instead of use GitHub URL, because it's needs git executable on install.