### PR TITLE
Fix link to options section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This package does not respect the order of patterns. First, all the negative pat
 
   * Type: `Object`
 
-See [options](https://github.com/mrmlnc/fast-glob#Options) section for more detailed information.
+See [options](#options-1) section for more detailed information.
 
 ### fg.sync(patterns, [options])
 


### PR DESCRIPTION
The main options heading is `options-1`.

Removing everything from the url but the hash fragment makes the link work on both npm and Github.
