### PR TITLE
ISSUE-54: Change double-negative options

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,26 @@ Return absolute paths for matched entries.
 
 Disable expansion of brace patterns (`{a,b}`, `{1..3}`).
 
+#### brace
+
+  * Type: `boolean`
+  * Default: `true`
+
+The [`nobrace`](#nobrace) option without double-negation. This option has a higher priority then `nobrace`.
+
 #### noglobstar
 
   * Type: `boolean`
   * Default: `false`
 
 Disable matching with globstars (`**`).
+
+#### globstar
+
+  * Type: `boolean`
+  * Default: `true`
+
+The [`noglobstar`](#noglobstar) option without double-negation. This option has a higher priority then `noglobstar`.
 
 #### noext
 
@@ -188,12 +202,26 @@ Disable matching with globstars (`**`).
 
 Disable extglob support (patterns like `+(a|b)`), so that extglobs are regarded as literal characters.
 
+#### extension
+
+  * Type: `boolean`
+  * Default: `true`
+
+The [`noext`](#noext) option without double-negation. This option has a higher priority then `noext`.
+
 #### nocase
 
   * Type: `boolean`
   * Default: `false`
 
-Use a case-insensitive regex for matching files.
+Disable a case-insensitive regex for matching files.
+
+#### case
+
+  * Type: `boolean`
+  * Default: `true`
+
+The [`nocase`](#nocase) option without double-negation. This option has a higher priority then `nocase`.
 
 #### matchBase
 
@@ -267,10 +295,10 @@ Not fully, because `fast-glob` does not implement all options of `node-glob`. Se
 | `mark`       | [`markDirectories`](#markdirectories) |
 | `nosort`     | – |
 | `nounique`   | [`unique`](#unique) |
-| `nobrace`    | [`nobrace`](#nobrace) |
-| `noglobstar` | [`noglobstar`](#noglobstar) |
-| `noext`      | [`noext`](#noext) |
-| `nocase`     | [`nocase`](#nocase) |
+| `nobrace`    | [`nobrace`](#nobrace) or [`brace`](#brace) |
+| `noglobstar` | [`noglobstar`](#noglobstar) or [`globstar`](#globstar) |
+| `noext`      | [`noext`](#noext) or [`extension`](#extension) |
+| `nocase`     | [`nocase`](#nocase) or [`case`](#case) |
 | `matchBase`  | [`matchbase`](#matchbase) |
 | `nodir`      | [`onlyFiles`](#onlyfiles) |
 | `ignore`     | [`ignore`](#ignore) |

--- a/src/managers/options.spec.ts
+++ b/src/managers/options.spec.ts
@@ -16,9 +16,13 @@ function getOptions(options?: manager.IPartialOptions): manager.IOptions {
 		markDirectories: false,
 		absolute: false,
 		nobrace: false,
+		brace: true,
 		noglobstar: false,
+		globstar: true,
 		noext: false,
+		extension: true,
 		nocase: false,
+		case: true,
 		matchBase: false,
 		transform: null
 	}, options);
@@ -51,6 +55,110 @@ describe('Managers → Options', () => {
 			const actual = manager.prepare({ onlyDirectories: true });
 
 			assert.deepEqual(actual, expected);
+		});
+
+		describe('The «brace» option', () => {
+			it('should set false for the «brace» option if «nobrace» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ brace: false, nobrace: true });
+
+				const actual = manager.prepare({ nobrace: true });
+
+				assert.deepEqual(actual, expected);
+			});
+
+			it('should set false for the «brace» option if «brace» option is disabled', () => {
+				const expected: manager.IOptions = getOptions({ brace: false });
+
+				const actual = manager.prepare({ brace: false });
+
+				assert.deepEqual(actual, expected);
+			});
+
+			it('should set true for the «brace» option if «brace» and «nobrace» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ brace: true, nobrace: true });
+
+				const actual = manager.prepare({ brace: true, nobrace: true });
+
+				assert.deepEqual(actual, expected);
+			});
+		});
+
+		describe('The «globstar» option', () => {
+			it('should set false for the «globstar» option if «noglobstar» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ globstar: false, noglobstar: true });
+
+				const actual = manager.prepare({ noglobstar: true });
+
+				assert.deepEqual(actual, expected);
+			});
+
+			it('should set false for the «globstar» option if «globstar» option is disabled', () => {
+				const expected: manager.IOptions = getOptions({ globstar: false });
+
+				const actual = manager.prepare({ globstar: false });
+
+				assert.deepEqual(actual, expected);
+			});
+
+			it('should set true for the «globstar» option if «globstar» and «noglobstar» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ globstar: true, noglobstar: true });
+
+				const actual = manager.prepare({ globstar: true, noglobstar: true });
+
+				assert.deepEqual(actual, expected);
+			});
+		});
+
+		describe('The «extension» option', () => {
+			it('should set false for the «extension» option if «noext» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ extension: false, noext: true });
+
+				const actual = manager.prepare({ noext: true });
+
+				assert.deepEqual(actual, expected);
+			});
+
+			it('should set false for the «extension» option if «extension» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ extension: false });
+
+				const actual = manager.prepare({ extension: false });
+
+				assert.deepEqual(actual, expected);
+			});
+
+			it('should set true for the «extension» option if «extension» and «noext» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ extension: true, noext: true });
+
+				const actual = manager.prepare({ extension: true, noext: true });
+
+				assert.deepEqual(actual, expected);
+			});
+		});
+
+		describe('The «case» option', () => {
+			it('should set false for the «case» option if «nocase» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ case: false, nocase: true });
+
+				const actual = manager.prepare({ nocase: true });
+
+				assert.deepEqual(actual, expected);
+			});
+
+			it('should set false for the «case» option if «case» option is disabled', () => {
+				const expected: manager.IOptions = getOptions({ case: false });
+
+				const actual = manager.prepare({ case: false });
+
+				assert.deepEqual(actual, expected);
+			});
+
+			it('should set true for the «extension» option if «case» and «nocase» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ case: true, nocase: true });
+
+				const actual = manager.prepare({ case: true, nocase: true });
+
+				assert.deepEqual(actual, expected);
+			});
 		});
 	});
 });

--- a/src/managers/options.ts
+++ b/src/managers/options.ts
@@ -55,17 +55,33 @@ export interface IOptions<T = EntryItem> {
 	 */
 	nobrace: boolean;
 	/**
+	 * Enable expansion of brace patterns.
+	 */
+	brace: boolean;
+	/**
 	 * Disable matching with globstars (`**`).
 	 */
 	noglobstar: boolean;
+	/**
+	 * Enable matching with globstars (`**`).
+	 */
+	globstar: boolean;
 	/**
 	 * Disable extglob support, so that extglobs are regarded as literal characters.
 	 */
 	noext: boolean;
 	/**
-	 * Use a case-insensitive regex for matching files.
+	 * Enable extglob support, so that extglobs are regarded as literal characters.
+	 */
+	extension: boolean;
+	/**
+	 * Disable a case-insensitive regex for matching files.
 	 */
 	nocase: boolean;
+	/**
+	 * Enable a case-insensitive regex for matching files.
+	 */
+	case: boolean;
 	/**
 	 * Allow glob patterns without slashes to match a file path based on its basename.
 	 * For example, `a?b` would match the path `/xyz/123/acb`, but not `/xyz/acb/123`.
@@ -93,15 +109,31 @@ export function prepare(options?: IPartialOptions): IOptions {
 		markDirectories: false,
 		absolute: false,
 		nobrace: false,
+		brace: true,
 		noglobstar: false,
+		globstar: true,
 		noext: false,
+		extension: true,
 		nocase: false,
+		case: true,
 		matchBase: false,
 		transform: null
 	}, options);
 
 	if (opts.onlyDirectories) {
 		opts.onlyFiles = false;
+	}
+
+	opts.brace = !opts.nobrace;
+	opts.globstar = !opts.noglobstar;
+	opts.extension = !opts.noext;
+	opts.case = !opts.nocase;
+
+	if (options) {
+		opts.brace = ('brace' in options ? options.brace : opts.brace) as boolean;
+		opts.globstar = ('globstar' in options ? options.globstar : opts.globstar) as boolean;
+		opts.extension = ('extension' in options ? options.extension : opts.extension) as boolean;
+		opts.case = ('case' in options ? options.case : opts.case) as boolean;
 	}
 
 	return opts;

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -54,10 +54,10 @@ export default abstract class Reader {
 	public getMicromatchOptions(): micromatch.Options {
 		return {
 			dot: this.options.dot,
-			nobrace: this.options.nobrace,
-			noglobstar: this.options.noglobstar,
-			noext: this.options.noext,
-			nocase: this.options.nocase,
+			nobrace: !this.options.brace,
+			noglobstar: !this.options.globstar,
+			noext: !this.options.extension,
+			nocase: !this.options.case,
 			matchBase: this.options.matchBase
 		};
 	}


### PR DESCRIPTION
### What is the purpose of this pull request?

Ability to use options without double negation.

> Double-negative options is a bad developer experience. It's better to just invert the default.

Related to #54.

### What changes did you make? (Give an overview)

  * Added additional options without negation.
  * Use additional options in the package as inverted value.