### PR TITLE
GLOBBY-74: No match found when pattern contains parentheses

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
   },
   "dependencies": {
     "@mrmlnc/readdir-enhanced": "^2.2.1",
-    "glob-parent": "3.1.0",
-    "merge2": "1.2.1",
-    "micromatch": "3.1.8"
+    "glob-parent": "^3.1.0",
+    "merge2": "^1.2.1",
+    "micromatch": "^3.1.8"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@mrmlnc/readdir-enhanced": "^2.2.1",
     "glob-parent": "3.1.0",
     "merge2": "1.2.1",
-    "micromatch": "3.1.5"
+    "micromatch": "3.1.8"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -181,7 +181,7 @@ describe('Utils → Pattern', () => {
 
 	describe('.makePatternRe', () => {
 		it('should return regexp for provided pattern', () => {
-			const expected: RegExp = /^(?:(?:(?:\.(?:\/|\\))(?=.))?(?!\/)(?!\.)(?=.)[^\/]*?\.js(?:(?:\/|\\)|$))$/;
+			const expected: RegExp = /^(?:(?:\.[\\/](?=.))?(?![\\/])(?!\.)(?=.)[^\\/]*?\.js(?:[\\/]|$))$/;
 
 			const actual = util.makeRe('*.js', {});
 
@@ -191,7 +191,7 @@ describe('Utils → Pattern', () => {
 
 	describe('.convertPatternsToRe', () => {
 		it('should return regexps for provided patterns', () => {
-			const expected: RegExp = /^(?:(?:(?:\.(?:\/|\\))(?=.))?(?!\/)(?!\.)(?=.)[^\/]*?\.js(?:(?:\/|\\)|$))$/;
+			const expected: RegExp = /^(?:(?:\.[\\/](?=.))?(?![\\/])(?!\.)(?=.)[^\\/]*?\.js(?:[\\/]|$))$/;
 
 			const [actual] = util.convertPatternsToRe(['*.js'], {});
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Just update dependencies for fix https://github.com/sindresorhus/globby/issues/74.

### What changes did you make? (Give an overview)

  * Update `micromatch` version
  * Allow minor updates