### PR TITLE
ISSUE-60: Time to find a non glob path increase with number of files in the same directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/glob-parent": "^3.1.0",
     "@types/glob-stream": "^6.1.0",
     "@types/globby": "^6.1.0",
+    "@types/is-glob": "^4.0.0",
     "@types/merge2": "^1.1.4",
     "@types/micromatch": "^3.1.0",
     "@types/minimist": "^1.2.0",
@@ -49,6 +50,7 @@
   "dependencies": {
     "@mrmlnc/readdir-enhanced": "^2.2.1",
     "glob-parent": "^3.1.0",
+    "is-glob": "^4.0.0",
     "merge2": "^1.2.1",
     "micromatch": "^3.1.8"
   },

--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -51,7 +51,7 @@ describe('Managers → Task', () => {
 				negative: ['*.md']
 			}];
 
-			const actual = manager.convertPatternsToTasks(['*', '!*.md'], [], /* dynamic */ true);
+			const actual = manager.convertPatternsToTasks(['*'], ['*.md'], /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -88,30 +88,7 @@ describe('Managers → Task', () => {
 				}
 			];
 
-			const actual = manager.convertPatternsToTasks(['a/*', 'b/*', '!b/*.md'], [], /* dynamic */ true);
-
-			assert.deepEqual(actual, expected);
-		});
-
-		it('should return two tasks with global negative patterns from «ignore» patterns', () => {
-			const expected: ITask[] = [
-				{
-					base: 'a',
-					dynamic: true,
-					patterns: ['a/*', '!*.md'],
-					positive: ['a/*'],
-					negative: ['*.md']
-				},
-				{
-					base: 'b',
-					dynamic: true,
-					patterns: ['b/*', '!*.md'],
-					positive: ['b/*'],
-					negative: ['*.md']
-				}
-			];
-
-			const actual = manager.convertPatternsToTasks(['a/*', 'b/*'], ['*.md'], /* dynamic */ true);
+			const actual = manager.convertPatternsToTasks(['a/*', 'b/*'], ['b/*.md'], /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -175,7 +152,7 @@ describe('Managers → Task', () => {
 	});
 
 	describe('.convertPatternGroupToTask', () => {
-		it('should return created task', () => {
+		it('should return created dynamic task', () => {
 			const expected: ITask = {
 				base: '.',
 				dynamic: true,

--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -39,6 +39,31 @@ describe('Managers → Task', () => {
 
 			assert.deepEqual(actual, expected);
 		});
+
+		it('should return static and dynamic tasks', () => {
+			const options = optionsManager.prepare({ ignore: ['*.txt'] });
+
+			const expected: ITask[] = [
+				{
+					base: 'a',
+					dynamic: false,
+					patterns: ['a/file.json', '!*.txt'],
+					positive: ['a/file.json'],
+					negative: ['*.txt']
+				},
+				{
+					base: 'b',
+					dynamic: true,
+					patterns: ['b/*', '!b/*.md', '!*.txt'],
+					positive: ['b/*'],
+					negative: ['b/*.md', '*.txt']
+				}
+			];
+
+			const actual = manager.generate(['a/file.json', 'b/*', '!b/*.md'], options);
+
+			assert.deepEqual(actual, expected);
+		});
 	});
 
 	describe('.convertPatternsToTasks', () => {
@@ -162,6 +187,20 @@ describe('Managers → Task', () => {
 			};
 
 			const actual = manager.convertPatternGroupToTask('.', ['*'], ['*.md'], /* dynamic */ true);
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should return created static task', () => {
+			const expected: ITask = {
+				base: '.',
+				dynamic: false,
+				patterns: ['file', '!file.md'],
+				positive: ['file'],
+				negative: ['file.md']
+			};
+
+			const actual = manager.convertPatternGroupToTask('.', ['file'], ['file.md'], /* dynamic */ false);
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -13,6 +13,7 @@ describe('Managers → Task', () => {
 
 			const expected: ITask[] = [{
 				base: 'a',
+				dynamic: true,
 				patterns: ['a/*'],
 				positive: ['a/*'],
 				negative: []
@@ -28,6 +29,7 @@ describe('Managers → Task', () => {
 
 			const expected: ITask[] = [{
 				base: 'a',
+				dynamic: true,
 				patterns: ['a/*', '!*.md', '!*.txt'],
 				positive: ['a/*'],
 				negative: ['*.md', '*.txt']
@@ -43,12 +45,13 @@ describe('Managers → Task', () => {
 		it('should return global task when positive patterns have a global pattern', () => {
 			const expected: ITask[] = [{
 				base: '.',
+				dynamic: true,
 				patterns: ['*', '!*.md'],
 				positive: ['*'],
 				negative: ['*.md']
 			}];
 
-			const actual = manager.convertPatternsToTasks(['*', '!*.md'], []);
+			const actual = manager.convertPatternsToTasks(['*', '!*.md'], [], /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -56,12 +59,13 @@ describe('Managers → Task', () => {
 		it('should return global task with negative patterns from «ignore» patterns', () => {
 			const expected: ITask[] = [{
 				base: '.',
+				dynamic: true,
 				patterns: ['*', '!*.md'],
 				positive: ['*'],
 				negative: ['*.md']
 			}];
 
-			const actual = manager.convertPatternsToTasks(['*'], ['*.md']);
+			const actual = manager.convertPatternsToTasks(['*'], ['*.md'], /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -70,19 +74,21 @@ describe('Managers → Task', () => {
 			const expected: ITask[] = [
 				{
 					base: 'a',
+					dynamic: true,
 					patterns: ['a/*'],
 					positive: ['a/*'],
 					negative: []
 				},
 				{
 					base: 'b',
+					dynamic: true,
 					patterns: ['b/*', '!b/*.md'],
 					positive: ['b/*'],
 					negative: ['b/*.md']
 				}
 			];
 
-			const actual = manager.convertPatternsToTasks(['a/*', 'b/*', '!b/*.md'], []);
+			const actual = manager.convertPatternsToTasks(['a/*', 'b/*', '!b/*.md'], [], /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -91,19 +97,21 @@ describe('Managers → Task', () => {
 			const expected: ITask[] = [
 				{
 					base: 'a',
+					dynamic: true,
 					patterns: ['a/*', '!*.md'],
 					positive: ['a/*'],
 					negative: ['*.md']
 				},
 				{
 					base: 'b',
+					dynamic: true,
 					patterns: ['b/*', '!*.md'],
 					positive: ['b/*'],
 					negative: ['*.md']
 				}
 			];
 
-			const actual = manager.convertPatternsToTasks(['a/*', 'b/*'], ['*.md']);
+			const actual = manager.convertPatternsToTasks(['a/*', 'b/*'], ['*.md'], /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -170,12 +178,13 @@ describe('Managers → Task', () => {
 		it('should return created task', () => {
 			const expected: ITask = {
 				base: '.',
+				dynamic: true,
 				patterns: ['*', '!*.md'],
 				positive: ['*'],
 				negative: ['*.md']
 			};
 
-			const actual = manager.convertPatternGroupToTask('.', ['*'], ['*.md']);
+			const actual = manager.convertPatternGroupToTask('.', ['*'], ['*.md'], /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -185,12 +194,13 @@ describe('Managers → Task', () => {
 		it('should return one task without negative patterns', () => {
 			const expected: ITask[] = [{
 				base: 'a',
+				dynamic: true,
 				patterns: ['a/*'],
 				positive: ['a/*'],
 				negative: []
 			}];
 
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, {});
+			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, {}, /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -198,12 +208,13 @@ describe('Managers → Task', () => {
 		it('should return one task without unused negative patterns', () => {
 			const expected: ITask[] = [{
 				base: 'a',
+				dynamic: true,
 				patterns: ['a/*'],
 				positive: ['a/*'],
 				negative: []
 			}];
 
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, { b: ['b/*'] });
+			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, { b: ['b/*'] }, /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -211,12 +222,13 @@ describe('Managers → Task', () => {
 		it('should return one task with local and global negative patterns', () => {
 			const expected: ITask[] = [{
 				base: 'a',
+				dynamic: true,
 				patterns: ['a/*', '!a/*.txt', '!*.md'],
 				positive: ['a/*'],
 				negative: ['a/*.txt', '*.md']
 			}];
 
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, { '.': ['*.md'], a: ['a/*.txt'] });
+			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, { '.': ['*.md'], a: ['a/*.txt'] }, /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -225,19 +237,21 @@ describe('Managers → Task', () => {
 			const expected: ITask[] = [
 				{
 					base: 'a',
+					dynamic: true,
 					patterns: ['a/*'],
 					positive: ['a/*'],
 					negative: []
 				},
 				{
 					base: 'b',
+					dynamic: true,
 					patterns: ['b/*', '!b/*.md'],
 					positive: ['b/*'],
 					negative: ['b/*.md']
 				}
 			];
 
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'], b: ['b/*'] }, { b: ['b/*.md'] });
+			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'], b: ['b/*'] }, { b: ['b/*.md'] }, /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -246,19 +260,21 @@ describe('Managers → Task', () => {
 			const expected: ITask[] = [
 				{
 					base: 'a',
+					dynamic: true,
 					patterns: ['a/*', '!*.md'],
 					positive: ['a/*'],
 					negative: ['*.md']
 				},
 				{
 					base: 'b',
+					dynamic: true,
 					patterns: ['b/*', '!*.md'],
 					positive: ['b/*'],
 					negative: ['*.md']
 				}
 			];
 
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'], b: ['b/*'] }, { '.': ['*.md'] });
+			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'], b: ['b/*'] }, { '.': ['*.md'] }, /* dynamic */ true);
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -21,7 +21,13 @@ export function generate(patterns: Pattern[], options: IOptions): ITask[] {
 	const positivePatterns = getPositivePatterns(unixPatterns);
 	const negativePatterns = getNegativePatternsAsPositive(unixPatterns, unixIgnore);
 
-	return convertPatternsToTasks(positivePatterns, negativePatterns, /* dynamic */ true);
+	const staticPatterns = positivePatterns.filter(patternUtils.isStaticPattern);
+	const dynamicPatterns = positivePatterns.filter(patternUtils.isDynamicPattern);
+
+	const staticTasks = convertPatternsToTasks(staticPatterns, negativePatterns, /* dynamic */ false);
+	const dynamicTasks = convertPatternsToTasks(dynamicPatterns, negativePatterns, /* dynamic */ true);
+
+	return staticTasks.concat(dynamicTasks);
 }
 
 /**

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -18,23 +18,23 @@ export function generate(patterns: Pattern[], options: IOptions): ITask[] {
 	const unixPatterns = patterns.map(patternUtils.unixifyPattern);
 	const unixIgnore = options.ignore.map(patternUtils.unixifyPattern);
 
-	return convertPatternsToTasks(unixPatterns, unixIgnore, /* dynamic */ true);
+	const positivePatterns = getPositivePatterns(unixPatterns);
+	const negativePatterns = getNegativePatternsAsPositive(unixPatterns, unixIgnore);
+
+	return convertPatternsToTasks(positivePatterns, negativePatterns, /* dynamic */ true);
 }
 
 /**
  * Convert patterns to tasks based on parent directory of each pattern.
  */
-export function convertPatternsToTasks(patterns: Pattern[], ignore: Pattern[], dynamic: boolean): ITask[] {
-	const positivePatterns = getPositivePatterns(patterns);
-	const negativePatterns = getNegativePatternsAsPositive(patterns, ignore);
-
-	const positivePatternsGroup = groupPatternsByBaseDirectory(positivePatterns);
-	const negativePatternsGroup = groupPatternsByBaseDirectory(negativePatterns);
+export function convertPatternsToTasks(positive: Pattern[], negative: Pattern[], dynamic: boolean): ITask[] {
+	const positivePatternsGroup = groupPatternsByBaseDirectory(positive);
+	const negativePatternsGroup = groupPatternsByBaseDirectory(negative);
 
 	// When we have a global group – there is no reason to divide the patterns into independent tasks.
 	// In this case, the global task covers the rest.
 	if ('.' in positivePatternsGroup) {
-		const task = convertPatternGroupToTask('.', positivePatterns, negativePatterns, dynamic);
+		const task = convertPatternGroupToTask('.', positive, negative, dynamic);
 
 		return [task];
 	}

--- a/src/providers/reader-async.spec.ts
+++ b/src/providers/reader-async.spec.ts
@@ -46,6 +46,7 @@ describe('Providers → ReaderAsync', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
+			dynamic: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader-stream.spec.ts
+++ b/src/providers/reader-stream.spec.ts
@@ -64,6 +64,7 @@ describe('Providers → ReaderStream', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
+			dynamic: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader-sync.spec.ts
+++ b/src/providers/reader-sync.spec.ts
@@ -41,6 +41,7 @@ describe('Providers → ReaderSync', () => {
 	describe('.read', () => {
 		const task: ITask = {
 			base: 'fixtures',
+			dynamic: true,
 			patterns: ['**/*'],
 			positive: ['**/*'],
 			negative: []

--- a/src/providers/reader.spec.ts
+++ b/src/providers/reader.spec.ts
@@ -59,6 +59,7 @@ describe('Providers → Reader', () => {
 
 			const actual = reader.getReaderOptions({
 				base: '.',
+				dynamic: true,
 				patterns: ['**/*'],
 				positive: ['**/*'],
 				negative: []
@@ -75,6 +76,7 @@ describe('Providers → Reader', () => {
 
 			const actual = reader.getReaderOptions({
 				base: 'fixtures',
+				dynamic: true,
 				patterns: ['**/*'],
 				positive: ['**/*'],
 				negative: []

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -5,6 +5,34 @@ import * as util from './pattern';
 import { Pattern } from '../types/patterns';
 
 describe('Utils → Pattern', () => {
+	describe('.isStaticPattern', () => {
+		it('should return true for static pattern', () => {
+			const actual = util.isStaticPattern('dir');
+
+			assert.ok(actual);
+		});
+
+		it('should return false for dynamic pattern', () => {
+			const actual = util.isStaticPattern('*');
+
+			assert.ok(!actual);
+		});
+	});
+
+	describe('.isDynamicPattern', () => {
+		it('should return true for dynamic pattern', () => {
+			const actual = util.isDynamicPattern('*');
+
+			assert.ok(actual);
+		});
+
+		it('should return false for static pattern', () => {
+			const actual = util.isDynamicPattern('dir');
+
+			assert.ok(!actual);
+		});
+	});
+
 	describe('.unixifyPattern', () => {
 		it('should convert backslashes to forward slashes', () => {
 			const expected: Pattern = '**/*';

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -1,9 +1,24 @@
 import globParent = require('glob-parent');
+import isGlob = require('is-glob');
 import micromatch = require('micromatch');
 
 import { Pattern, PatternRe } from '../types/patterns';
 
 const GLOBSTAR = '**';
+
+/**
+ * Return true for static pattern.
+ */
+export function isStaticPattern(pattern: Pattern): boolean {
+	return !isDynamicPattern(pattern);
+}
+
+/**
+ * Return true for pattern that looks like glob.
+ */
+export function isDynamicPattern(pattern: Pattern): boolean {
+	return isGlob(pattern);
+}
 
 /**
  * Convert a windows «path» to a unix-style «path».


### PR DESCRIPTION
### What is the purpose of this pull request?

This is the first step for #60. The ability to split tasks into two types: static and dynamic.

  * **static** – non-dynamic patterns.
  * **dynamic** – [`is-glob`](https://github.com/micromatch/is-glob) positive check.

### What changes did you make? (Give an overview)

  * Utils for separating static and dynamic patterns (based on `is-glob` package).
  * Mark tasks by `dynamic: boolean` property.