### PR TITLE
ISSUE-69: Doesn't exclude entries when pattern ends with globstar or includes pattern

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -145,14 +145,6 @@ describe('Managers → Task', () => {
 
 			assert.deepEqual(actual, expected);
 		});
-
-		it('should return negative patterns as positive with cut slash globstar', () => {
-			const expected = ['**/node_modules', '**/.git'];
-
-			const actual = manager.getNegativePatternsAsPositive(['**/*', '!**/node_modules/**'], ['**/.git/**']);
-
-			assert.deepEqual(actual, expected);
-		});
 	});
 
 	describe('.groupPatternsByBaseDirectory', () => {

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -62,7 +62,7 @@ export function getNegativePatternsAsPositive(patterns: Pattern[], ignore: Patte
 	const negative = patternUtils.getNegativePatterns(patterns);
 	const positive = negative.map(patternUtils.convertToPositivePattern).concat(ignore);
 
-	return positive.map(patternUtils.trimTrailingSlashGlobStar);
+	return positive;
 }
 
 /**

--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -273,8 +273,38 @@ describe('Providers → Filters → Entry', () => {
 				assert.ok(actual);
 			});
 
+			it('should return true for directory that matched to static patterns', () => {
+				const filter = getFilter(['fixtures/directory'], [], { onlyFiles: false });
+
+				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
+
+				const actual = filter(entry);
+
+				assert.ok(actual);
+			});
+
 			it('should return false for directory that not matched to patterns', () => {
 				const filter = getFilter(['**/super_directory/**'], [], { onlyFiles: false });
+
+				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
+
+				const actual = filter(entry);
+
+				assert.ok(!actual);
+			});
+
+			it('should return false for directory that matched to negative static pattern', () => {
+				const filter = getFilter(['**'], ['fixtures/directory'], { onlyFiles: false });
+
+				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
+
+				const actual = filter(entry);
+
+				assert.ok(!actual);
+			});
+
+			it('should return false for directory that matched to negative pattern with globstar', () => {
+				const filter = getFilter(['**'], ['fixtures/directory/**'], { onlyFiles: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 

--- a/src/tests/smoke/regular.smoke.ts
+++ b/src/tests/smoke/regular.smoke.ts
@@ -35,10 +35,10 @@ smoke.suite('Smoke → Regular (ignore)', [
 
 	[
 		{ pattern: 'fixtures/*', ignore: 'fixtures/*' },
-		{ pattern: 'fixtures/*', ignore: 'fixtures/**', broken: true, issue: 69 },
+		{ pattern: 'fixtures/*', ignore: 'fixtures/**' },
 		{ pattern: 'fixtures/*', ignore: 'fixtures/**/*' },
 		{ pattern: 'fixtures/**', ignore: 'fixtures/*', broken: true, issue: 80 },
-		{ pattern: 'fixtures/**', ignore: 'fixtures/**', broken: true, issue: 69 },
+		{ pattern: 'fixtures/**', ignore: 'fixtures/**' },
 		{
 			pattern: 'fixtures/**',
 			ignore: 'fixtures/**/*',
@@ -46,7 +46,7 @@ smoke.suite('Smoke → Regular (ignore)', [
 			reason: 'The negative pattern excludes any entries (files and directories) at any nesting level.'
 		},
 		{ pattern: 'fixtures/**/*', ignore: 'fixtures/*', broken: true, issue: 80 },
-		{ pattern: 'fixtures/**/*', ignore: 'fixtures/**', broken: true, issue: 69 },
+		{ pattern: 'fixtures/**/*', ignore: 'fixtures/**' },
 		{ pattern: 'fixtures/**/*', ignore: 'fixtures/**/*' }
 	],
 

--- a/src/tests/smoke/smoke.ts
+++ b/src/tests/smoke/smoke.ts
@@ -66,7 +66,7 @@ function getTestCaseTitle(test: ISmokeTest): string {
 		title += `, ignore: '${test.ignore}'`;
 	}
 	if (test.broken) {
-		title += ' (broken)';
+		title += ` (broken - ${test.issue})`;
 	}
 	if (test.correct) {
 		title += ' (correct)';

--- a/src/tests/smoke/static.smoke.ts
+++ b/src/tests/smoke/static.smoke.ts
@@ -22,7 +22,7 @@ smoke.suite('Smoke → Static (ignore)', [
 		{ pattern: 'fixtures/file.md', ignore: 'fixtures/file.md' },
 		{ pattern: 'fixtures/file.md', ignore: 'fixtures/*.md' },
 		{ pattern: 'fixtures/file.md', ignore: 'fixtures/*' },
-		{ pattern: 'fixtures/file.md', ignore: 'fixtures/**', broken: true, issue: 69 },
+		{ pattern: 'fixtures/file.md', ignore: 'fixtures/**' },
 		{ pattern: 'fixtures/file.md', ignore: 'fixtures/**/*' }
 	],
 
@@ -32,9 +32,9 @@ smoke.suite('Smoke → Static (ignore)', [
 		{ pattern: 'fixtures/first', ignore: '*' },
 		{ pattern: 'fixtures/first', ignore: '**' },
 		{ pattern: 'fixtures/first', ignore: '**/*' },
-		{ pattern: 'fixtures/first', ignore: 'fixtures/first', broken: true, issue: 69 },
+		{ pattern: 'fixtures/first', ignore: 'fixtures/first' },
 		{ pattern: 'fixtures/first', ignore: 'fixtures/*' },
-		{ pattern: 'fixtures/first', ignore: 'fixtures/**', broken: true, issue: 69 },
+		{ pattern: 'fixtures/first', ignore: 'fixtures/**' },
 		{ pattern: 'fixtures/first', ignore: 'fixtures/**/*' }
 	]
 ]);

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -159,52 +159,6 @@ describe('Utils → Pattern', () => {
 		});
 	});
 
-	describe('.endsWithSlashGlobStar', () => {
-		it('should returns true for pattern that ends with slash and globstar', () => {
-			const actual = util.endsWithSlashGlobStar('name/**');
-
-			assert.ok(actual);
-		});
-
-		it('should returns false for pattern that has no slash, but ends with globstar', () => {
-			const actual = util.endsWithSlashGlobStar('**');
-
-			assert.ok(!actual);
-		});
-
-		it('should returns false for pattern that does not ends with globstar', () => {
-			const actual = util.endsWithSlashGlobStar('name/**/*');
-
-			assert.ok(!actual);
-		});
-	});
-
-	describe('.trimTrailingSlashGlobStar', () => {
-		it('should returns pattern without globstar when pattern ends with slash and globstar', () => {
-			const expected = 'name';
-
-			const actual = util.trimTrailingSlashGlobStar('name/**');
-
-			assert.equal(actual, expected);
-		});
-
-		it('should returns original pattern when pattern ends with globstar, but has no slash', () => {
-			const expected = '**';
-
-			const actual = util.trimTrailingSlashGlobStar('**');
-
-			assert.equal(actual, expected);
-		});
-
-		it('should returns original pattern when pattern does not ends with globstar', () => {
-			const expected = 'name/*';
-
-			const actual = util.trimTrailingSlashGlobStar('name/*');
-
-			assert.equal(actual, expected);
-		});
-	});
-
 	describe('.getDepth', () => {
 		it('should returns 4', () => {
 			const expected: number = 4;

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -201,24 +201,4 @@ describe('Utils → Pattern', () => {
 			assert.ok(!actual);
 		});
 	});
-
-	describe('.match', () => {
-		it('should return false by negative patterns', () => {
-			const actual = util.match('fixtures/file.txt', [], [/fixtures\/file/]);
-
-			assert.ok(!actual);
-		});
-
-		it('should return false by positive patterns', () => {
-			const actual = util.match('fixtures/file.txt', [/fixtures\/file\.md/], []);
-
-			assert.ok(!actual);
-		});
-
-		it('should return true', () => {
-			const actual = util.match('fixtures/file.txt', [/fixtures\/file\.txt/], []);
-
-			assert.ok(actual);
-		});
-	});
 });

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -116,10 +116,3 @@ export function matchAny(entry: string, patternsRe: PatternRe[]): boolean {
 
 	return false;
 }
-
-/**
- * Returns true if the entry doesn't match any of the given negative RegExp's and match any of the given positive RegExp's.
- */
-export function match(entry: string, positiveRe: PatternRe[], negativeRe: PatternRe[]): boolean {
-	return matchAny(entry, negativeRe) ? false : matchAny(entry, positiveRe);
-}

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -84,20 +84,6 @@ export function hasGlobStar(pattern: Pattern): boolean {
 }
 
 /**
- * Return true if provided pattern ends with slash and globstar.
- */
-export function endsWithSlashGlobStar(pattern: Pattern): boolean {
-	return pattern.endsWith('/' + GLOBSTAR);
-}
-
-/**
- * Trim trailing globstar if provided pattern ends with slash and globstar.
- */
-export function trimTrailingSlashGlobStar(pattern: Pattern): Pattern {
-	return endsWithSlashGlobStar(pattern) ? pattern.slice(0, -3) : pattern;
-}
-
-/**
  * Return naive depth of provided pattern.
  */
 export function getDepth(pattern: Pattern): number {


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for #69.

### What changes did you make? (Give an overview)

  * Drop some unnecessary conversion and functions
  * Correct application of patterns to the entry