### PR TITLE
ISSUE-78, ISSUE-80: Ability to prevent deep reading correctly 

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,12 @@ const entries: IMyOwnEntry[] = fg.sync<IMyOwnEntry>(['*.md'], {
 
 You can use a negative pattern like this: `!**/node_modules` or `!**/node_modules/**`. Also you can use `ignore` option. Just look at the example below.
 
-  * **first/**
-    * **second/**
-      * file.md
-    * file.md
+```
+first/
+├── file.md
+└── second
+    └── file.txt
+```
 
 If you don't want to read the `second` directory, you must write the following pattern: `!**/second` or `!**/second/**`.
 

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -86,8 +86,8 @@ describe('Providers → Filters → Deep', () => {
 			});
 		});
 
-		describe('Filter by «followSymlinkedDirectories» option', () => {
-			it('should return true for symlinked directory when option is enabled', () => {
+		describe('Skip by «followSymlinkedDirectories» option', () => {
+			it('should return «true» for symlinked directory when option is enabled', () => {
 				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, true /** isSymbolicLink */);
@@ -97,7 +97,7 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(actual);
 			});
 
-			it('should return false for symlinked directory when option is disabled', () => {
+			it('should return «false» for symlinked directory when option is disabled', () => {
 				const filter = getFilter(['**/*'], [], { followSymlinkedDirectories: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, true /** isSymbolicLink */);

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -130,8 +130,8 @@ describe('Providers → Filters → Deep', () => {
 			});
 		});
 
-		describe('Filter by patterns', () => {
-			it('should return true for directory when negative patterns is not defined', () => {
+		describe('Skip by negative patterns', () => {
+			it('should return «true» when negative patterns is not defined', () => {
 				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
@@ -141,7 +141,7 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(actual);
 			});
 
-			it('should return true for directory that not matched to negative patterns', () => {
+			it('should return «true» when the directory does not match to negative patterns', () => {
 				const filter = getFilter(['**/*'], ['**/pony/**']);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
@@ -151,8 +151,8 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(actual);
 			});
 
-			it('should return true for directory when negative patterns has globstar and star after directory name', () => {
-				const filter = getFilter(['**/*'], ['**/directory/**/*']);
+			it('should return «true» when negative patterns has no effect to depth reading', () => {
+				const filter = getFilter(['**/*'], ['*', '**/*']);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -161,8 +161,18 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(actual);
 			});
 
-			it('should return false for directory that matched to negative patterns', () => {
-				const filter = getFilter([], ['**/directory']);
+			it('should return «false» when the directory match to negative patterns', () => {
+				const filter = getFilter(['**/*'], ['fixtures/directory']);
+
+				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
+
+				const actual = filter(entry);
+
+				assert.ok(!actual);
+			});
+
+			it('should return «false» when the directory match to negative patterns with effect to depth reading', () => {
+				const filter = getFilter(['**/*'], ['fixtures/**']);
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
@@ -171,59 +181,19 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(!actual);
 			});
 		});
+	});
 
-		describe('Filter by «depth» parameter', () => {
-			it('should return true if the patterns have a globstar', () => {
-				const filter = getFilter(['**/*'], []);
+	describe('Immutability', () => {
+		it('should return the data without changes', () => {
+			const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
-				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
+			const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
 
-				const actual = filter(entry);
+			const expected = entry.path;
 
-				assert.ok(actual);
-			});
+			filter(entry);
 
-			it('should return true if the patterns have a depth greater than the entry', () => {
-				const filter = getFilter(['fixtures/*/*'], []);
-
-				const entry = tests.getEntry({
-					path: 'fixtures/directory/directory',
-					depth: 3,
-					isDirectory: () => true
-				});
-
-				const actual = filter(entry);
-
-				assert.ok(actual);
-			});
-
-			it('should return false if the patterns have a depth smaller than the entry', () => {
-				const filter = getFilter(['fixtures/*'], []);
-
-				const entry = tests.getEntry({
-					path: 'fixtures/directory/directory',
-					depth: 3,
-					isDirectory: () => true
-				});
-
-				const actual = filter(entry);
-
-				assert.ok(!actual);
-			});
-		});
-
-		describe('Immutability', () => {
-			it('should return the data without changes', () => {
-				const filter = getFilter(['**/*'], [], { onlyFiles: false });
-
-				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
-
-				const expected = entry.path;
-
-				filter(entry);
-
-				assert.equal(entry.path, expected);
-			});
+			assert.equal(entry.path, expected);
 		});
 	});
 });

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -108,8 +108,8 @@ describe('Providers → Filters → Deep', () => {
 			});
 		});
 
-		describe('Filter by «dot» option', () => {
-			it('should return true for directory that starting with a period when option is enabled', () => {
+		describe('Skip by «dot» option', () => {
+			it('should return «true» for directory that starting with a period when option is enabled', () => {
 				const filter = getFilter(['**/*'], [], { onlyFiles: false, dot: true });
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);
@@ -119,7 +119,7 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(actual);
 			});
 
-			it('should return false for directory that starting with a period when option is disabled', () => {
+			it('should return «false» for directory that starting with a period when option is disabled', () => {
 				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -31,9 +31,9 @@ describe('Providers → Filters → Deep', () => {
 		});
 	});
 
-	describe('.call', () => {
-		describe('Filter by «deep» option', () => {
-			it('should return false for nested directory when option is disabled', () => {
+	describe('.filter', () => {
+		describe('Skip by nesting level', () => {
+			it('should return «false» when option is disabled', () => {
 				const filter = getFilter(['**/*'], [], { deep: false });
 
 				const entry = tests.getDirectoryEntry(false /** dot */, false /** isSymbolicLink */);
@@ -43,8 +43,36 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(!actual);
 			});
 
-			it('should return false for nested directory when option has specified level', () => {
+			it('should return «false» when option has specified level', () => {
 				const filter = getFilter(['**/*'], [], { deep: 2 });
+
+				const entry = tests.getEntry({
+					path: 'fixtures/directory/directory',
+					depth: 3,
+					isDirectory: () => true
+				});
+
+				const actual = filter(entry);
+
+				assert.ok(!actual);
+			});
+
+			it('should return «true» when depth is smaller than allowed', () => {
+				const filter = getFilter(['fixtures/*/*'], []);
+
+				const entry = tests.getEntry({
+					path: 'fixtures/directory/directory',
+					depth: 3,
+					isDirectory: () => true
+				});
+
+				const actual = filter(entry);
+
+				assert.ok(actual);
+			});
+
+			it('should return «false» when depth is greater than allowed', () => {
+				const filter = getFilter(['fixtures/*'], []);
 
 				const entry = tests.getEntry({
 					path: 'fixtures/directory/directory',

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -49,12 +49,7 @@ export default class DeepFilter {
 			return false;
 		}
 
-		// Skip by negative patterns
-		if (patternUtils.matchAny(entry.path, negativeRe)) {
-			return false;
-		}
-
-		return true;
+		return this.isSkippedByNegativePatterns(entry, negativeRe);
 	}
 
 	/**
@@ -90,5 +85,12 @@ export default class DeepFilter {
 	 */
 	private isSkippedDotDirectory(entry: Entry): boolean {
 		return !this.options.dot && pathUtils.isDotDirectory(entry.path);
+	}
+
+	/**
+	 * Returns «true» for a directory whose path math to any negative pattern.
+	 */
+	private isSkippedByNegativePatterns(entry: Entry, negativeRe: PatternRe[]): boolean {
+		return !patternUtils.matchAny(entry.path, negativeRe);
 	}
 }

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -18,7 +18,7 @@ export default class DeepFilter {
 	 */
 	public getFilter(positive: Pattern[], negative: Pattern[]): FilterFunction {
 		const maxPatternDepth = this.getMaxPatternDepth(positive);
-		const negativeRe: PatternRe[] = patternUtils.convertPatternsToRe(negative, this.micromatchOptions);
+		const negativeRe: PatternRe[] = this.getNegativePatternsRe(negative);
 
 		return (entry: Entry) => this.filter(entry, negativeRe, maxPatternDepth);
 	}
@@ -31,6 +31,15 @@ export default class DeepFilter {
 		const patternDepths = patterns.map(patternUtils.getDepth);
 
 		return globstar ? Infinity : arrayUtils.max(patternDepths);
+	}
+
+	/**
+	 * Returns RegExp's for patterns that can affect the depth of reading.
+	 */
+	private getNegativePatternsRe(patterns: Pattern[]): PatternRe[] {
+		const affectDepthOfReadingPatterns: Pattern[] = patterns.filter(patternUtils.isAffectDepthOfReadingPattern);
+
+		return patternUtils.convertPatternsToRe(affectDepthOfReadingPatterns, this.micromatchOptions);
 	}
 
 	/**

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -45,8 +45,7 @@ export default class DeepFilter {
 			return false;
 		}
 
-		// Skip reading if the directory name starting with a period and is not expected
-		if (this.isFollowedDotDirectory(entry)) {
+		if (this.isSkippedDotDirectory(entry)) {
 			return false;
 		}
 
@@ -87,9 +86,9 @@ export default class DeepFilter {
 	}
 
 	/**
-	 * Returns «true» for dot directories if the «dot» option is enabled.
+	 * Returns «true» for a directory whose name starts with a period.
 	 */
-	private isFollowedDotDirectory(entry: Entry): boolean {
+	private isSkippedDotDirectory(entry: Entry): boolean {
 		return !this.options.dot && pathUtils.isDotDirectory(entry.path);
 	}
 }

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -41,8 +41,7 @@ export default class DeepFilter {
 			return false;
 		}
 
-		// Skip reading if the directory is symlink and we don't want expand symlinks
-		if (this.isFollowedSymlink(entry)) {
+		if (this.isSkippedSymlinkedDirectory(entry)) {
 			return false;
 		}
 
@@ -81,16 +80,16 @@ export default class DeepFilter {
 	}
 
 	/**
+	 * Returns «true» for symlinked directory if the «followSymlinkedDirectories» option is disabled.
+	 */
+	private isSkippedSymlinkedDirectory(entry: Entry): boolean {
+		return !this.options.followSymlinkedDirectories && entry.isSymbolicLink();
+	}
+
+	/**
 	 * Returns «true» for dot directories if the «dot» option is enabled.
 	 */
 	private isFollowedDotDirectory(entry: Entry): boolean {
 		return !this.options.dot && pathUtils.isDotDirectory(entry.path);
-	}
-
-	/**
-	 * Returns «true» for symlinked directories if the «followSymlinks» option is enabled.
-	 */
-	private isFollowedSymlink(entry: Entry): boolean {
-		return !this.options.followSymlinkedDirectories && entry.isSymbolicLink();
 	}
 }

--- a/src/tests/smoke/regular.smoke.ts
+++ b/src/tests/smoke/regular.smoke.ts
@@ -37,10 +37,10 @@ smoke.suite('Smoke → Regular (ignore)', [
 		{ pattern: 'fixtures/*', ignore: 'fixtures/*' },
 		{ pattern: 'fixtures/*', ignore: 'fixtures/**' },
 		{ pattern: 'fixtures/*', ignore: 'fixtures/**/*' },
-		{ pattern: 'fixtures/**', ignore: 'fixtures/*', broken: true, issue: [47, 80] },
+		{ pattern: 'fixtures/**', ignore: 'fixtures/*', broken: true, issue: 47 },
 		{ pattern: 'fixtures/**', ignore: 'fixtures/**' },
 		{ pattern: 'fixtures/**', ignore: 'fixtures/**/*', broken: true, issue: 47 },
-		{ pattern: 'fixtures/**/*', ignore: 'fixtures/*', broken: true, issue: 80 },
+		{ pattern: 'fixtures/**/*', ignore: 'fixtures/*' },
 		{ pattern: 'fixtures/**/*', ignore: 'fixtures/**' },
 		{ pattern: 'fixtures/**/*', ignore: 'fixtures/**/*' }
 	],
@@ -76,14 +76,9 @@ smoke.suite('Smoke → Regular (ignore)', [
 		{ pattern: 'fixtures/*', ignore: '*/nested/*' },
 		{ pattern: 'fixtures/*', ignore: '**/nested/*' },
 		{ pattern: 'fixtures/**', ignore: '*/nested/*', broken: true, issue: 47 },
-		{
-			pattern: 'fixtures/**',
-			ignore: '**/nested/*',
-			broken: true,
-			issue: [47, 80]
-		},
+		{ pattern: 'fixtures/**', ignore: '**/nested/*', broken: true, issue: 47 },
 		{ pattern: 'fixtures/**/*', ignore: '*/nested/*' },
-		{ pattern: 'fixtures/**/*', ignore: '**/nested/*', broken: true, issue: 80 }
+		{ pattern: 'fixtures/**/*', ignore: '**/nested/*' }
 	],
 
 	[
@@ -147,7 +142,7 @@ smoke.suite('Smoke → Regular (ignore)', [
 		{ pattern: 'fixtures/*/nested/**', ignore: '*/nested/*' },
 		{ pattern: 'fixtures/*/nested/**', ignore: '*/nested/**' },
 		{ pattern: 'fixtures/*/nested/**', ignore: '*/nested/**/*' },
-		{ pattern: 'fixtures/*/nested/**', ignore: '**/nested/*', broken: true, issue: 80 },
+		{ pattern: 'fixtures/*/nested/**', ignore: '**/nested/*' },
 		{ pattern: 'fixtures/*/nested/**', ignore: '**/nested/**' },
 		{ pattern: 'fixtures/*/nested/**', ignore: '**/nested/**/*' }
 	],
@@ -163,7 +158,7 @@ smoke.suite('Smoke → Regular (ignore)', [
 		{ pattern: 'fixtures/*/nested/**/*', ignore: '*/nested/*' },
 		{ pattern: 'fixtures/*/nested/**/*', ignore: '*/nested/**' },
 		{ pattern: 'fixtures/*/nested/**/*', ignore: '*/nested/**/*' },
-		{ pattern: 'fixtures/*/nested/**/*', ignore: '**/nested/*', broken: true, issue: 80 },
+		{ pattern: 'fixtures/*/nested/**/*', ignore: '**/nested/*' },
 		{ pattern: 'fixtures/*/nested/**/*', ignore: '**/nested/**' },
 		{ pattern: 'fixtures/*/nested/**/*', ignore: '**/nested/**/*' }
 	],
@@ -195,7 +190,7 @@ smoke.suite('Smoke → Regular (ignore)', [
 		{ pattern: 'fixtures/**/nested/**', ignore: '*/nested/*' },
 		{ pattern: 'fixtures/**/nested/**', ignore: '*/nested/**' },
 		{ pattern: 'fixtures/**/nested/**', ignore: '*/nested/**/*' },
-		{ pattern: 'fixtures/**/nested/**', ignore: '**/nested/*', broken: true, issue: 80 },
+		{ pattern: 'fixtures/**/nested/**', ignore: '**/nested/*' },
 		{ pattern: 'fixtures/**/nested/**', ignore: '**/nested/**' },
 		{ pattern: 'fixtures/**/nested/**', ignore: '**/nested/**/*' }
 	],
@@ -211,7 +206,7 @@ smoke.suite('Smoke → Regular (ignore)', [
 		{ pattern: 'fixtures/**/nested/**/*', ignore: '*/nested/*' },
 		{ pattern: 'fixtures/**/nested/**/*', ignore: '*/nested/**' },
 		{ pattern: 'fixtures/**/nested/**/*', ignore: '*/nested/**/*' },
-		{ pattern: 'fixtures/**/nested/**/*', ignore: '**/nested/*', broken: true, issue: 80 },
+		{ pattern: 'fixtures/**/nested/**/*', ignore: '**/nested/*' },
 		{ pattern: 'fixtures/**/nested/**/*', ignore: '**/nested/**' },
 		{ pattern: 'fixtures/**/nested/**/*', ignore: '**/nested/**/*' }
 	]
@@ -222,10 +217,10 @@ smoke.suite('Smoke → Regular (ignore & cwd)', [
 		{ pattern: '*', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '*', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '*', ignore: '**/*', cwd: 'fixtures' },
-		{ pattern: '**', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '**', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '**', ignore: '**/*', cwd: 'fixtures' },
-		{ pattern: '**/*', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**/*', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '**/*', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '**/*', ignore: '**/*', cwd: 'fixtures' }
 	],
@@ -287,10 +282,10 @@ smoke.suite('Smoke → Regular (ignore & cwd)', [
 	[
 		{ pattern: '*', ignore: '*/nested/*', cwd: 'fixtures' },
 		{ pattern: '*', ignore: '**/nested/*', cwd: 'fixtures' },
-		{ pattern: '**', ignore: '*/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
-		{ pattern: '**', ignore: '**/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
-		{ pattern: '**/*', ignore: '*/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
-		{ pattern: '**/*', ignore: '**/nested/*', cwd: 'fixtures', broken: true, issue: 80 }
+		{ pattern: '**', ignore: '*/nested/*', cwd: 'fixtures' },
+		{ pattern: '**', ignore: '**/nested/*', cwd: 'fixtures' },
+		{ pattern: '**/*', ignore: '*/nested/*', cwd: 'fixtures' },
+		{ pattern: '**/*', ignore: '**/nested/*', cwd: 'fixtures' }
 	],
 
 	[
@@ -312,7 +307,7 @@ smoke.suite('Smoke → Regular (ignore & cwd)', [
 	],
 
 	[
-		{ pattern: '*/nested', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '*/nested', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '*/nested', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '*/nested', ignore: '**/*', cwd: 'fixtures' },
 		{ pattern: '*/nested', ignore: 'nested', cwd: 'fixtures' },
@@ -328,7 +323,7 @@ smoke.suite('Smoke → Regular (ignore & cwd)', [
 	],
 
 	[
-		{ pattern: '*/nested/*', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '*/nested/*', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '*/nested/*', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '*/nested/*', ignore: '**/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/*', ignore: 'nested', cwd: 'fixtures' },
@@ -344,39 +339,39 @@ smoke.suite('Smoke → Regular (ignore & cwd)', [
 	],
 
 	[
-		{ pattern: '*/nested/**', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '*/nested/**', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: '**/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: 'nested', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: 'nested/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: 'nested/**', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: 'nested/**/*', cwd: 'fixtures' },
-		{ pattern: '*/nested/**', ignore: '*/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '*/nested/**', ignore: '*/nested/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: '*/nested/**', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: '*/nested/**/*', cwd: 'fixtures' },
-		{ pattern: '*/nested/**', ignore: '**/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '*/nested/**', ignore: '**/nested/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: '**/nested/**', cwd: 'fixtures' },
 		{ pattern: '*/nested/**', ignore: '**/nested/**/*', cwd: 'fixtures' }
 	],
 
 	[
-		{ pattern: '*/nested/**/*', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '*/nested/**/*', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: '**/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: 'nested', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: 'nested/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: 'nested/**', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: 'nested/**/*', cwd: 'fixtures' },
-		{ pattern: '*/nested/**/*', ignore: '*/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '*/nested/**/*', ignore: '*/nested/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: '*/nested/**', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: '*/nested/**/*', cwd: 'fixtures' },
-		{ pattern: '*/nested/**/*', ignore: '**/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '*/nested/**/*', ignore: '**/nested/*', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: '**/nested/**', cwd: 'fixtures' },
 		{ pattern: '*/nested/**/*', ignore: '**/nested/**/*', cwd: 'fixtures' }
 	],
 
 	[
-		{ pattern: '**/nested/*', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**/nested/*', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '**/nested/*', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '**/nested/*', ignore: '**/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/*', ignore: 'nested', cwd: 'fixtures' },
@@ -392,33 +387,33 @@ smoke.suite('Smoke → Regular (ignore & cwd)', [
 	],
 
 	[
-		{ pattern: '**/nested/**', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**/nested/**', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: '**/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: 'nested', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: 'nested/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: 'nested/**', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: 'nested/**/*', cwd: 'fixtures' },
-		{ pattern: '**/nested/**', ignore: '*/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**/nested/**', ignore: '*/nested/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: '*/nested/**', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: '*/nested/**/*', cwd: 'fixtures' },
-		{ pattern: '**/nested/**', ignore: '**/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**/nested/**', ignore: '**/nested/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: '**/nested/**', cwd: 'fixtures' },
 		{ pattern: '**/nested/**', ignore: '**/nested/**/*', cwd: 'fixtures' }
 	],
 
 	[
-		{ pattern: '**/nested/**/*', ignore: '*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**/nested/**/*', ignore: '*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: '**', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: '**/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: 'nested', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: 'nested/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: 'nested/**', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: 'nested/**/*', cwd: 'fixtures' },
-		{ pattern: '**/nested/**/*', ignore: '*/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**/nested/**/*', ignore: '*/nested/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: '*/nested/**', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: '*/nested/**/*', cwd: 'fixtures' },
-		{ pattern: '**/nested/**/*', ignore: '**/nested/*', cwd: 'fixtures', broken: true, issue: 80 },
+		{ pattern: '**/nested/**/*', ignore: '**/nested/*', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: '**/nested/**', cwd: 'fixtures' },
 		{ pattern: '**/nested/**/*', ignore: '**/nested/**/*', cwd: 'fixtures' }
 	]

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,13 +1,10 @@
 import * as path from 'path';
 
 /**
- * Returns true if the last partial of the path starting with a period.
+ * Returns «true» if the last partial of the path starting with a period.
  */
 export function isDotDirectory(filepath: string): boolean {
-	const pathPartials = filepath.split('/');
-	const lastPathPartial: string = pathPartials[pathPartials.length - 1];
-
-	return lastPathPartial.startsWith('.');
+	return path.basename(filepath).startsWith('.');
 }
 
 /**
@@ -25,7 +22,7 @@ export function resolve(from: string, to: string): string {
 }
 
 /**
- * Convert a windows «path» to a unix-style «path».
+ * Convert a windows-like path to a unix-style path.
  */
 export function normalize(filepath: string): string {
 	return filepath.replace(/\\/g, '/');

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -159,6 +159,26 @@ describe('Utils → Pattern', () => {
 		});
 	});
 
+	describe('.endsWithSlashGlobStar', () => {
+		it('should returns true for pattern that ends with slash and globstar', () => {
+			const actual = util.endsWithSlashGlobStar('name/**');
+
+			assert.ok(actual);
+		});
+
+		it('should returns false for pattern that has no slash, but ends with globstar', () => {
+			const actual = util.endsWithSlashGlobStar('**');
+
+			assert.ok(!actual);
+		});
+
+		it('should returns false for pattern that does not ends with globstar', () => {
+			const actual = util.endsWithSlashGlobStar('name/**/*');
+
+			assert.ok(!actual);
+		});
+	});
+
 	describe('.getDepth', () => {
 		it('should returns 4', () => {
 			const expected: number = 4;

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -179,6 +179,26 @@ describe('Utils → Pattern', () => {
 		});
 	});
 
+	describe('.isAffectDepthOfReadingPattern', () => {
+		it('should return true for pattern that ends with slash and globstar', () => {
+			const actual = util.isAffectDepthOfReadingPattern('name/**');
+
+			assert.ok(actual);
+		});
+
+		it('should return true for pattern when the last partial of the pattern is static pattern', () => {
+			const actual = util.isAffectDepthOfReadingPattern('**/name');
+
+			assert.ok(actual);
+		});
+
+		it('should return false', () => {
+			const actual = util.isAffectDepthOfReadingPattern('**/name/*');
+
+			assert.ok(!actual);
+		});
+	});
+
 	describe('.getDepth', () => {
 		it('should returns 4', () => {
 			const expected: number = 4;

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -84,6 +84,13 @@ export function hasGlobStar(pattern: Pattern): boolean {
 }
 
 /**
+ * Return true if provided pattern ends with slash and globstar.
+ */
+export function endsWithSlashGlobStar(pattern: Pattern): boolean {
+	return pattern.endsWith('/' + GLOBSTAR);
+}
+
+/**
  * Return naive depth of provided pattern.
  */
 export function getDepth(pattern: Pattern): number {

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 import globParent = require('glob-parent');
 import isGlob = require('is-glob');
 import micromatch = require('micromatch');
@@ -88,6 +90,15 @@ export function hasGlobStar(pattern: Pattern): boolean {
  */
 export function endsWithSlashGlobStar(pattern: Pattern): boolean {
 	return pattern.endsWith('/' + GLOBSTAR);
+}
+
+/**
+ * Returns «true» when pattern ends with a slash and globstar or the last partial of the pattern is static pattern.
+ */
+export function isAffectDepthOfReadingPattern(pattern: Pattern): boolean {
+	const basename = path.basename(pattern);
+
+	return endsWithSlashGlobStar(pattern) || isStaticPattern(basename);
 }
 
 /**


### PR DESCRIPTION
### What is the purpose of this pull request?

This is potential fix for #78 and #80.

### What changes did you make? (Give an overview)

Now directories are excluded from reading only if negative pattern affect the depth reading:

  * Ends with a `/**`
  * Ends with a static pattern (`**/node_modules`)

### WIP

  * [x] Checking the correctness of the solution
  * [x] Benchmark
  * [x] More tests for `deep` filter
  * [x] Update [docs](https://github.com/mrmlnc/fast-glob#how-to-exclude-directory-from-reading)