### PR TITLE
ISSUE-93: Incorrect filter for static patterns

### DIFF
--- a/src/providers/reader-async.ts
+++ b/src/providers/reader-async.ts
@@ -54,7 +54,7 @@ export default class ReaderAsync extends Reader<Promise<EntryItem[]>> {
 	public staticApi(task: ITask): NodeJS.ReadableStream {
 		const fsAdapter = new FileSystemStream(this.options);
 
-		const filter = this.entryFilter.getFilter(['**'], task.negative);
+		const filter = this.entryFilter.getFilter(task.positive, task.negative);
 
 		return fsAdapter.read(task.patterns, filter);
 	}

--- a/src/providers/reader-stream.ts
+++ b/src/providers/reader-stream.ts
@@ -59,7 +59,7 @@ export default class ReaderStream extends Reader<NodeJS.ReadableStream> {
 	public staticApi(task: ITask): NodeJS.ReadableStream {
 		const fsAdapter = new FileSystemStream(this.options);
 
-		const filter = this.entryFilter.getFilter(['**'], task.negative);
+		const filter = this.entryFilter.getFilter(task.positive, task.negative);
 
 		return fsAdapter.read(task.patterns, filter);
 	}

--- a/src/providers/reader-sync.ts
+++ b/src/providers/reader-sync.ts
@@ -52,7 +52,7 @@ export default class ReaderSync extends Reader<EntryItem[]> {
 	public staticApi(task: ITask): Entry[] {
 		const fsAdapter = new FileSystemSync(this.options);
 
-		const filter = this.entryFilter.getFilter(['**'], task.negative);
+		const filter = this.entryFilter.getFilter(task.positive, task.negative);
 
 		return fsAdapter.read(task.patterns, filter);
 	}

--- a/src/tests/smoke/regular.smoke.ts
+++ b/src/tests/smoke/regular.smoke.ts
@@ -418,3 +418,8 @@ smoke.suite('Smoke → Regular (ignore & cwd)', [
 		{ pattern: '**/nested/**/*', ignore: '**/nested/**/*', cwd: 'fixtures' }
 	]
 ]);
+
+smoke.suite('Smoke → Regular (relative)', [
+	{ pattern: '../*', cwd: 'fixtures/first' },
+	{ pattern: '../../*', cwd: 'fixtures/first/nested' }
+]);

--- a/src/tests/smoke/static.smoke.ts
+++ b/src/tests/smoke/static.smoke.ts
@@ -57,3 +57,8 @@ smoke.suite('Smoke → Static (ignore & cwd)', [
 		{ pattern: 'fixtures/first', ignore: '**/*', cwd: 'fixtures' }
 	]
 ]);
+
+smoke.suite('Smoke → Static (relative)', [
+	{ pattern: '../file.md', cwd: 'fixtures/first' },
+	{ pattern: '../../file.md', cwd: 'fixtures/first/nested' }
+]);


### PR DESCRIPTION
### What is the purpose of this pull request?

This is fix for https://github.com/mrmlnc/fast-glob/issues/93.

When we work with static patterns, we use the `**` pattern. Unfortunately, this does not cover cases with relative paths. 

### What changes did you make? (Give an overview)

We have to work with real patterns.