### PR TITLE
ISSUE-101: Incorrect negative pattern detection

### DIFF
--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -83,6 +83,12 @@ describe('Utils → Pattern', () => {
 
 			assert.ok(!actual);
 		});
+
+		it('should returns false for extglob', () => {
+			const actual = util.isNegativePattern('!(a|b|c)');
+
+			assert.ok(!actual);
+		});
 	});
 
 	describe('.isPositivePattern', () => {

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -47,7 +47,7 @@ export function convertToNegativePattern(pattern: Pattern): Pattern {
  * Return true if provided pattern is negative pattern.
  */
 export function isNegativePattern(pattern: Pattern): boolean {
-	return pattern.startsWith('!');
+	return pattern.startsWith('!') && pattern[1] !== '(';
 }
 
 /**


### PR DESCRIPTION
### What is the purpose of this pull request?

This is fix for #101.

### What changes did you make? (Give an overview)

The `!(a|b|c)` pattern is matches anything except one of the given patterns.

