### PR TITLE
ISSUE-86: Allow to use inverted negative patterns

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -120,10 +120,18 @@ describe('Managers → Task', () => {
 	});
 
 	describe('.getPositivePatterns', () => {
-		it('should return only positive patterns', () => {
+		it('should return positive patterns from patterns', () => {
 			const expected = ['*'];
 
-			const actual = manager.getPositivePatterns(['*', '!*.md']);
+			const actual = manager.getPositivePatterns(['*', '!*.md'], ['*.txt']);
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should return inverted negative patterns from ignore option', () => {
+			const expected = ['**/*'];
+
+			const actual = manager.getPositivePatterns(['*', '!*.md'], ['!**/*', '*.txt']);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -139,7 +147,15 @@ describe('Managers → Task', () => {
 		});
 
 		it('should return negative patterns as positive with patterns from ignore option', () => {
-			const expected = ['*.md', '*.txt', '*.json'];
+			const expected = ['*.md', '*.txt'];
+
+			const actual = manager.getNegativePatternsAsPositive(['*', '!*.md'], ['*.txt']);
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should return negative patterns as positive without inverted negative patterns from ignore option', () => {
+			const expected = ['*.md', '*.txt'];
 
 			const actual = manager.getNegativePatternsAsPositive(['*', '!*.md'], ['*.txt', '!*.json']);
 

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -18,7 +18,7 @@ export function generate(patterns: Pattern[], options: IOptions): ITask[] {
 	const unixPatterns = patterns.map(patternUtils.unixifyPattern);
 	const unixIgnore = options.ignore.map(patternUtils.unixifyPattern);
 
-	const positivePatterns = getPositivePatterns(unixPatterns);
+	const positivePatterns = getPositivePatterns(unixPatterns, unixIgnore);
 	const negativePatterns = getNegativePatternsAsPositive(unixPatterns, unixIgnore);
 
 	const staticPatterns = positivePatterns.filter(patternUtils.isStaticPattern);
@@ -49,17 +49,23 @@ export function convertPatternsToTasks(positive: Pattern[], negative: Pattern[],
 }
 
 /**
- * Return only positive patterns.
+ * Return only positive or only inverted negative patterns.
  */
-export function getPositivePatterns(patterns: Pattern[]): Pattern[] {
+export function getPositivePatterns(patterns: Pattern[], ignore: Pattern[]): Pattern[] {
+	const inversedIgnore = patternUtils.getNegativePatterns(ignore);
+	if (inversedIgnore.length !== 0) {
+		return inversedIgnore.map(patternUtils.convertToPositivePattern);
+	}
+
 	return patternUtils.getPositivePatterns(patterns);
 }
 
 /**
- * Return only negative patterns.
+ * Return only negative patterns without inverted negative patterns.
  */
 export function getNegativePatternsAsPositive(patterns: Pattern[], ignore: Pattern[]): Pattern[] {
-	const negative = patternUtils.getNegativePatterns(patterns).concat(ignore);
+	const nonInversedIgnore = patternUtils.getPositivePatterns(ignore);
+	const negative = patternUtils.getNegativePatterns(patterns).concat(nonInversedIgnore);
 	const positive = negative.map(patternUtils.convertToPositivePattern);
 
 	return positive;

--- a/src/tests/smoke/ignore.smoke.ts
+++ b/src/tests/smoke/ignore.smoke.ts
@@ -3,12 +3,35 @@ import * as smoke from './smoke';
 smoke.suite('Smoke → Ignore', [
 	{
 		pattern: 'fixtures/**/*',
-		globOptions: { ignore: ['**/*.md'] },
-		fgOptions: { ignore: ['**/*.md'] }
+		globOptions: { ignore: ['*.md'] },
+		fgOptions: { ignore: ['*.md'] }
 	},
 	{
 		pattern: 'fixtures/**/*',
 		globOptions: { ignore: ['**/*.md'] },
-		fgOptions: { ignore: ['!**/*.md'] }
+		fgOptions: { ignore: ['**/*.md'] }
+	}
+]);
+
+smoke.suite('Smoke → Ignore (inverted)', [
+	{
+		pattern: 'fixtures/**/*',
+		globOptions: { ignore: ['!fixtures/*.md'] },
+		fgOptions: { ignore: ['!fixtures/*.md'] }
+	},
+	{
+		pattern: 'fixtures/**/*',
+		globOptions: { ignore: ['!fixtures/**/*.md'] },
+		fgOptions: { ignore: ['!fixtures/**/*.md'] }
+	},
+	{
+		pattern: 'fixtures/**/*',
+		globOptions: { ignore: ['!fixtures/**/nested/**/*'] },
+		fgOptions: { ignore: ['!fixtures/**/nested/**/*'] }
+	},
+	{
+		pattern: 'fixtures/**/*',
+		globOptions: { ignore: ['!fixtures/**/nested/**/*', '**/*.md'] },
+		fgOptions: { ignore: ['!fixtures/**/nested/**/*', '**/*.md'] }
 	}
 ]);

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -69,6 +69,14 @@ describe('Utils → Pattern', () => {
 
 			assert.equal(actual, expected);
 		});
+
+		it('should returns pattern without changes', () => {
+			const expected: Pattern = '!*.js';
+
+			const actual = util.convertToNegativePattern('!*.js');
+
+			assert.equal(actual, expected);
+		});
 	});
 
 	describe('.isNegativePattern', () => {

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -30,17 +30,17 @@ export function unixifyPattern(pattern: Pattern): Pattern {
 }
 
 /**
- * Returns negative pattern as positive pattern.
+ * Returns negative pattern as positive pattern if required.
  */
 export function convertToPositivePattern(pattern: Pattern): Pattern {
 	return isNegativePattern(pattern) ? pattern.slice(1) : pattern;
 }
 
 /**
- * Returns positive pattern as negative pattern.
+ * Returns positive pattern as negative pattern if required.
  */
 export function convertToNegativePattern(pattern: Pattern): Pattern {
-	return '!' + pattern;
+	return isNegativePattern(pattern) ? pattern : '!' + pattern;
 }
 
 /**


### PR DESCRIPTION
### What is the purpose of this pull request?

So, this is «present» PR for original problem described in the issue (#86).

### What changes did you make? (Give an overview)

This is introduction of the concept of «inverted negative patterns».

The **inverted negative pattern** is a usual negative pattern inside the `ignore` option. This pattern will be used as a positive pattern when searching.

**FileSystem Tree**

```
fixtures
├── invalid.bar
├── invalid.json
├── invalid.svg
├── invalid.txt
├── invalid.xml
└── nested
    ├── valid.abc
    ├── valid.json
    ├── valid.txt
    └── valid.svg
```

**Default behavior**

```js
const entries = fg.sync(['**/*'], {
    cwd: 'fixtures'
}).sort();

// [
//   'invalid.bar', 'invalid.json', 'invalid.svg', 'invalid.txt', 'invalid.xml',
//   'nested/valid.abc', 'nested/valid.json', 'nested/valid.txt', 'nested/valid.svg'
// ]
```

**Behavior with inverted negative patterns**

```js
const entries = fg.sync(['**/*'], {
    ignore: ['!*.txt'], // only files with the «txt» extension and only at any level of the tree
    cwd: 'fixtures'
}).sort();

// [ 'invalid.txt' ]
```

```js
const entries = fg.sync(['**/*'], {
    ignore: ['!**/*.{txt,svg}', '*'], // only txt or svg at any level of the tree, but not on the first
    cwd: 'fixtures'
}).sort();

// [ 'nested/valid.txt', 'nested/valid.svg' ]
```

```js
const entries = fg.sync(['**/*'], {
    ignore: ['!**/*.{txt,svg}', '**/*.txt'], // only svg at any level of the tree
    cwd: 'fixtures'
}).sort();

// [ 'invalid.svg', 'nested/valid.svg' ]
```