### PR TITLE
TRIVIAL: Use @nodelib/fs.stat in FS adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@mrmlnc/readdir-enhanced": "^2.2.1",
+    "@nodelib/fs.stat": "^1.0.1",
     "glob-parent": "^3.1.0",
     "is-glob": "^4.0.0",
     "merge2": "^1.2.1",

--- a/src/adapters/fs-stream.spec.ts
+++ b/src/adapters/fs-stream.spec.ts
@@ -14,12 +14,12 @@ import { Pattern } from '../types/patterns';
 const options = optionsManager.prepare();
 
 class FileSystemStreamFake extends FileSystemStream {
-	constructor(private readonly isSymbolicLink: boolean = true) {
+	constructor() {
 		super(options);
 	}
 
 	public getStat(): Promise<fs.Stats> {
-		return getStats(1, this.isSymbolicLink);
+		return getStats(1);
 	}
 }
 
@@ -33,16 +33,16 @@ class FileSystemStreamThrowStatError extends FileSystemStreamFake {
 			return Promise.reject(new Error('something'));
 		}
 
-		return getStats(1, /* isSymbolicLink */ true);
+		return getStats(1);
 	}
 }
 
-function getStats(uid: number, isSymbolicLink: boolean): Promise<fs.Stats> {
-	return Promise.resolve({ uid, isSymbolicLink: () => isSymbolicLink } as fs.Stats);
+function getStats(uid: number): Promise<fs.Stats> {
+	return Promise.resolve({ uid } as fs.Stats);
 }
 
-function getAdapter(isSymbolicLink: boolean = true): FileSystemStreamFake {
-	return new FileSystemStreamFake(isSymbolicLink);
+function getAdapter(): FileSystemStreamFake {
+	return new FileSystemStreamFake();
 }
 
 function getEntries(_adapter: new () => FileSystemStreamFake, positive: Pattern[], isSkippedEntry: boolean): Promise<string[]> {
@@ -106,8 +106,6 @@ describe('Adapters → FileSystemStream', () => {
 			} as Entry;
 
 			const actual = await adapter.getEntry('filepath', 'pattern');
-
-			delete (actual as Entry).isSymbolicLink;
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/adapters/fs-stream.spec.ts
+++ b/src/adapters/fs-stream.spec.ts
@@ -45,13 +45,13 @@ function getAdapter(): FileSystemStreamFake {
 	return new FileSystemStreamFake();
 }
 
-function getEntries(_adapter: new () => FileSystemStreamFake, positive: Pattern[], isSkippedEntry: boolean): Promise<string[]> {
+function getEntries(_adapter: new () => FileSystemStreamFake, positive: Pattern[], isFollowedEntry: boolean): Promise<string[]> {
 	const adapter = new _adapter();
 
 	const entries: string[] = [];
 
 	return new Promise((resolve, reject) => {
-		const stream = adapter.read(positive, () => isSkippedEntry);
+		const stream = adapter.read(positive, () => isFollowedEntry);
 
 		stream.on('data', (entry: Entry) => entries.push(entry.path));
 
@@ -73,7 +73,7 @@ describe('Adapters → FileSystemStream', () => {
 		it('should return empty array', async () => {
 			const expected: string[] = [];
 
-			const actual = await getEntries(FileSystemStreamFake, ['pattern1', 'pattern2'], /* isSkippedEntry */ false);
+			const actual = await getEntries(FileSystemStreamFake, ['pattern1', 'pattern2'], /* isFollowedEntry */ false);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -81,7 +81,7 @@ describe('Adapters → FileSystemStream', () => {
 		it('should return entries', async () => {
 			const expected = ['pattern1', 'pattern2'];
 
-			const actual = await getEntries(FileSystemStreamFake, ['pattern1', 'pattern2'], /* isSkippedEntry */ true);
+			const actual = await getEntries(FileSystemStreamFake, ['pattern1', 'pattern2'], /* isFollowedEntry */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -89,7 +89,7 @@ describe('Adapters → FileSystemStream', () => {
 		it('should return entries without null items', async () => {
 			const expected = ['pattern2'];
 
-			const actual = await getEntries(FileSystemStreamThrowStatError, ['pattern1', 'pattern2'], /* isSkippedEntry */ true);
+			const actual = await getEntries(FileSystemStreamThrowStatError, ['pattern1', 'pattern2'], /* isFollowedEntry */ true);
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/adapters/fs-stream.spec.ts
+++ b/src/adapters/fs-stream.spec.ts
@@ -18,41 +18,22 @@ class FileSystemStreamFake extends FileSystemStream {
 		super(options);
 	}
 
-	/**
-	 * Here «0» is an indicator that it is «lstat» call.
-	 */
-	public lstat(): Promise<fs.Stats> {
-		return getStats(0, this.isSymbolicLink);
-	}
-
-	/**
-	 * Here «1» is an indicator that it is «stat» call.
-	 */
-	public stat(): Promise<fs.Stats> {
+	public getStat(): Promise<fs.Stats> {
 		return getStats(1, this.isSymbolicLink);
 	}
 }
 
-class FileSystemStreamThrowLStatError extends FileSystemStreamFake {
+class FileSystemStreamThrowStatError extends FileSystemStreamFake {
 	private call: number = 0;
 
-	/**
-	 * First call throw error.
-	 */
-	public lstat(): Promise<fs.Stats> {
+	public getStat(): Promise<fs.Stats> {
 		if (this.call === 0) {
 			this.call++;
 
 			return Promise.reject(new Error('something'));
 		}
 
-		return super.lstat();
-	}
-}
-
-class FileSystemStreamThrowStatError extends FileSystemStreamFake {
-	public stat(): Promise<fs.Stats> {
-		return Promise.reject(new Error('something'));
+		return getStats(1, /* isSymbolicLink */ true);
 	}
 }
 
@@ -108,7 +89,7 @@ describe('Adapters → FileSystemSync', () => {
 		it('should return entries without null items', async () => {
 			const expected = ['pattern2'];
 
-			const actual = await getEntries(FileSystemStreamThrowLStatError, ['pattern1', 'pattern2'], /* isSkippedEntry */ true);
+			const actual = await getEntries(FileSystemStreamThrowStatError, ['pattern1', 'pattern2'], /* isSkippedEntry */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -132,51 +113,13 @@ describe('Adapters → FileSystemSync', () => {
 		});
 
 		it('should return null when lstat throw error', async () => {
-			const adapter = new FileSystemStreamThrowLStatError();
+			const adapter = new FileSystemStreamThrowStatError();
 
 			const expected = null;
 
 			const actual = await adapter.getEntry('filepath', 'pattern');
 
 			assert.equal(actual, expected);
-		});
-	});
-
-	describe('.getStat', () => {
-		it('should return stat', async () => {
-			const adapter = getAdapter();
-
-			const expected: fs.Stats = { uid: 1 } as fs.Stats;
-
-			const actual = await adapter.getStat('pattern');
-
-			delete actual.isSymbolicLink;
-
-			assert.deepEqual(actual, expected);
-		});
-
-		it('should return only lstat when is not a symlink', async () => {
-			const adapter = getAdapter(/* isSymbolicLink */ false);
-
-			const expected: fs.Stats = { uid: 0 } as fs.Stats;
-
-			const actual = await adapter.getStat('file.json');
-
-			delete actual.isSymbolicLink;
-
-			assert.deepEqual(actual, expected);
-		});
-
-		it('should return only lstat when stat call throw error', async () => {
-			const adapter = new FileSystemStreamThrowStatError();
-
-			const expected: fs.Stats = { uid: 0 } as fs.Stats;
-
-			const actual = await adapter.getStat('file.json');
-
-			delete actual.isSymbolicLink;
-
-			assert.deepEqual(actual, expected);
 		});
 	});
 });

--- a/src/adapters/fs-stream.spec.ts
+++ b/src/adapters/fs-stream.spec.ts
@@ -60,7 +60,7 @@ function getEntries(_adapter: new () => FileSystemStreamFake, positive: Pattern[
 	});
 }
 
-describe('Adapters → FileSystemSync', () => {
+describe('Adapters → FileSystemStream', () => {
 	describe('Constructor', () => {
 		it('should create instance of class', () => {
 			const adapter = getAdapter();

--- a/src/adapters/fs-stream.ts
+++ b/src/adapters/fs-stream.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as stream from 'stream';
 
+import * as fsStat from '@nodelib/fs.stat';
+
 import FileSystem from './fs';
 
 import { FilterFunction } from '@mrmlnc/readdir-enhanced';
@@ -51,30 +53,6 @@ export default class FileSystemStream extends FileSystem<NodeJS.ReadableStream> 
 	 * Return fs.Stats for the provided path.
 	 */
 	public getStat(filepath: string): Promise<fs.Stats> {
-		return this.lstat(filepath)
-			.then((lstat) => {
-				if (!lstat.isSymbolicLink()) {
-					return lstat;
-				}
-
-				return this.stat(filepath).catch(() => lstat);
-			})
-			.then((stat) => {
-				stat.isSymbolicLink = () => true;
-
-				return stat;
-			});
-	}
-
-	public lstat(filepath: string): Promise<fs.Stats> {
-		return new Promise((resolve, reject) => {
-			fs.lstat(filepath, (err: NodeJS.ErrnoException, stats: fs.Stats) => err ? reject(err) : resolve(stats));
-		});
-	}
-
-	public stat(filepath: string): Promise<fs.Stats> {
-		return new Promise((resolve, reject) => {
-			fs.stat(filepath, (err: NodeJS.ErrnoException, stats: fs.Stats) => err ? reject(err) : resolve(stats));
-		});
+		return fsStat.stat(filepath, { throwErrorOnBrokenSymlinks: false });
 	}
 }

--- a/src/adapters/fs-sync.spec.ts
+++ b/src/adapters/fs-sync.spec.ts
@@ -14,12 +14,12 @@ import { Pattern } from '../types/patterns';
 const options = optionsManager.prepare();
 
 class FileSystemSyncFake extends FileSystemSync {
-	constructor(private readonly isSymbolicLink: boolean = true) {
+	constructor() {
 		super(options);
 	}
 
 	public getStat(): fs.Stats {
-		return getStats(1, this.isSymbolicLink);
+		return getStats(1);
 	}
 }
 
@@ -36,16 +36,16 @@ class FileSystemSyncThrowStatError extends FileSystemSyncFake {
 			throw new Error('Something');
 		}
 
-		return getStats(1, /* isSymbolicLink */ true);
+		return getStats(1);
 	}
 }
 
-function getStats(uid: number, isSymbolicLink: boolean): fs.Stats {
-	return { uid, isSymbolicLink: () => isSymbolicLink } as fs.Stats;
+function getStats(uid: number): fs.Stats {
+	return { uid } as fs.Stats;
 }
 
-function getAdapter(isSymbolicLink: boolean = true): FileSystemSyncFake {
-	return new FileSystemSyncFake(isSymbolicLink);
+function getAdapter(): FileSystemSyncFake {
+	return new FileSystemSyncFake();
 }
 
 function getEntries(_adapter: new () => FileSystemSyncFake, positive: Pattern[], isSkippedEntry: boolean): string[] {
@@ -100,8 +100,6 @@ describe('Adapters → FileSystemSync', () => {
 			} as Entry;
 
 			const actual = adapter.getEntry('filepath', 'pattern');
-
-			delete (actual as Entry).isSymbolicLink;
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/adapters/fs-sync.spec.ts
+++ b/src/adapters/fs-sync.spec.ts
@@ -48,10 +48,10 @@ function getAdapter(): FileSystemSyncFake {
 	return new FileSystemSyncFake();
 }
 
-function getEntries(_adapter: new () => FileSystemSyncFake, positive: Pattern[], isSkippedEntry: boolean): string[] {
+function getEntries(_adapter: new () => FileSystemSyncFake, positive: Pattern[], isFollowedEntry: boolean): string[] {
 	const adapter = new _adapter();
 
-	return adapter.read(positive, () => isSkippedEntry).map(({ path }) => path);
+	return adapter.read(positive, () => isFollowedEntry).map(({ path }) => path);
 }
 
 describe('Adapters → FileSystemSync', () => {
@@ -67,7 +67,7 @@ describe('Adapters → FileSystemSync', () => {
 		it('should return empty array', () => {
 			const expected: string[] = [];
 
-			const actual = getEntries(FileSystemSyncFake, ['pattern1', 'pattern2'], /* isSkippedEntry */ false);
+			const actual = getEntries(FileSystemSyncFake, ['pattern1', 'pattern2'], /* isFollowedEntry */ false);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -75,7 +75,7 @@ describe('Adapters → FileSystemSync', () => {
 		it('should return entries', () => {
 			const expected = ['pattern1', 'pattern2'];
 
-			const actual = getEntries(FileSystemSyncFake, ['pattern1', 'pattern2'], /* isSkippedEntry */ true);
+			const actual = getEntries(FileSystemSyncFake, ['pattern1', 'pattern2'], /* isFollowedEntry */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -83,7 +83,7 @@ describe('Adapters → FileSystemSync', () => {
 		it('should return entries without null items', () => {
 			const expected = ['pattern2'];
 
-			const actual = getEntries(FileSystemSyncThrowStatError, ['pattern1', 'pattern2'], /* isSkippedEntry */ true);
+			const actual = getEntries(FileSystemSyncThrowStatError, ['pattern1', 'pattern2'], /* isFollowedEntry */ true);
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/adapters/fs-sync.spec.ts
+++ b/src/adapters/fs-sync.spec.ts
@@ -18,41 +18,25 @@ class FileSystemSyncFake extends FileSystemSync {
 		super(options);
 	}
 
-	/**
-	 * Here «0» is an indicator that it is «lstat» call.
-	 */
-	public lstat(): fs.Stats {
-		return getStats(0, this.isSymbolicLink);
-	}
-
-	/**
-	 * Here «1» is an indicator that it is «stat» call.
-	 */
-	public stat(): fs.Stats {
+	public getStat(): fs.Stats {
 		return getStats(1, this.isSymbolicLink);
 	}
 }
 
-class FileSystemSyncThrowLStatError extends FileSystemSyncFake {
+class FileSystemSyncThrowStatError extends FileSystemSyncFake {
 	private call: number = 0;
 
 	/**
 	 * First call throw error.
 	 */
-	public lstat(): fs.Stats | never {
+	public getStat(): fs.Stats | never {
 		if (this.call === 0) {
 			this.call++;
 
 			throw new Error('Something');
 		}
 
-		return super.lstat();
-	}
-}
-
-class FileSystemSyncThrowStatError extends FileSystemSyncFake {
-	public stat(): never {
-		throw new Error('Something');
+		return getStats(1, /* isSymbolicLink */ true);
 	}
 }
 
@@ -99,7 +83,7 @@ describe('Adapters → FileSystemSync', () => {
 		it('should return entries without null items', () => {
 			const expected = ['pattern2'];
 
-			const actual = getEntries(FileSystemSyncThrowLStatError, ['pattern1', 'pattern2'], /* isSkippedEntry */ true);
+			const actual = getEntries(FileSystemSyncThrowStatError, ['pattern1', 'pattern2'], /* isSkippedEntry */ true);
 
 			assert.deepEqual(actual, expected);
 		});
@@ -123,51 +107,13 @@ describe('Adapters → FileSystemSync', () => {
 		});
 
 		it('should return null when lstat throw error', () => {
-			const adapter = new FileSystemSyncThrowLStatError();
+			const adapter = new FileSystemSyncThrowStatError();
 
 			const expected = null;
 
 			const actual = adapter.getEntry('filepath', 'pattern');
 
 			assert.equal(actual, expected);
-		});
-	});
-
-	describe('.getStat', () => {
-		it('should return stat', () => {
-			const adapter = getAdapter();
-
-			const expected: fs.Stats = { uid: 1 } as fs.Stats;
-
-			const actual = adapter.getStat('pattern');
-
-			delete actual.isSymbolicLink;
-
-			assert.deepEqual(actual, expected);
-		});
-
-		it('should return only lstat when is not a symlink', () => {
-			const adapter = getAdapter(/* isSymbolicLink */ false);
-
-			const expected: fs.Stats = { uid: 0 } as fs.Stats;
-
-			const actual = adapter.getStat('file.json');
-
-			delete actual.isSymbolicLink;
-
-			assert.deepEqual(actual, expected);
-		});
-
-		it('should return only lstat when stat call throw error', () => {
-			const adapter = new FileSystemSyncThrowStatError();
-
-			const expected: fs.Stats = { uid: 0 } as fs.Stats;
-
-			const actual = adapter.getStat('file.json');
-
-			delete actual.isSymbolicLink;
-
-			assert.deepEqual(actual, expected);
 		});
 	});
 });

--- a/src/adapters/fs-sync.ts
+++ b/src/adapters/fs-sync.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 
+import * as fsStat from '@nodelib/fs.stat';
+
 import FileSystem from './fs';
 
 import { FilterFunction } from '@mrmlnc/readdir-enhanced';
@@ -45,28 +47,6 @@ export default class FileSystemSync extends FileSystem<Entry[]> {
 	 * Return fs.Stats for the provided path.
 	 */
 	public getStat(filepath: string): fs.Stats {
-		const lstat = this.lstat(filepath);
-
-		if (!lstat.isSymbolicLink()) {
-			return lstat;
-		}
-
-		try {
-			const stat = this.stat(filepath);
-
-			stat.isSymbolicLink = () => true;
-
-			return stat;
-		} catch {
-			return lstat;
-		}
-	}
-
-	public lstat(filepath: string): fs.Stats {
-		return fs.lstatSync(filepath);
-	}
-
-	public stat(filepath: string): fs.Stats {
-		return fs.statSync(filepath);
+		return fsStat.statSync(filepath, { throwErrorOnBrokenSymlinks: false });
 	}
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

This PR introduces `@nodelib/fs.stat` package instead of built-in solution.

### What changes did you make? (Give an overview)

* Use the `@nodelib/fs.stat` package.
* Fewer tests (they already exist in the package).