### PR TITLE
ISSUE-107: Fix incorrect search in negative patterns group

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import * as optionsManager from './options';
 import * as manager from './tasks';
 
-import { PatternsGroup } from '../types/patterns';
+import { Pattern, PatternsGroup } from '../types/patterns';
 import { ITask } from './tasks';
 
 describe('Managers → Task', () => {
@@ -193,6 +193,47 @@ describe('Managers → Task', () => {
 			};
 
 			const actual = manager.convertPatternGroupToTask('.', ['file'], ['file.md'], /* dynamic */ false);
+
+			assert.deepEqual(actual, expected);
+		});
+	});
+
+	describe('.findLocalNegativePatterns', () => {
+		it('should retrun empty array for empty pattern group', () => {
+			const expected: Pattern[] = [];
+
+			const actual = manager.findLocalNegativePatterns('base', {});
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should return the pattern group when the base path is fully matched', () => {
+			const expected: Pattern[] = ['base/*'];
+
+			const actual = manager.findLocalNegativePatterns('base', {
+				base: ['base/*']
+			});
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should return the pattern group when the base path is partial matched', () => {
+			const expected: Pattern[] = ['base/nested/*'];
+
+			const actual = manager.findLocalNegativePatterns('base', {
+				'base/nested': ['base/nested/*']
+			});
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should return the pattern group for all cases', () => {
+			const expected: Pattern[] = ['base/*', 'base/nested/*'];
+
+			const actual = manager.findLocalNegativePatterns('base', {
+				base: ['base/*'],
+				'base/nested': ['base/nested/*']
+			});
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -89,11 +89,24 @@ export function convertPatternGroupsToTasks(positive: PatternsGroup, negative: P
 	const globalNegative = '.' in negative ? negative['.'] : [];
 
 	return Object.keys(positive).map((base) => {
-		const localNegative = base in negative ? negative[base] : [];
+		const localNegative = findLocalNegativePatterns(base, negative);
 		const fullNegative = localNegative.concat(globalNegative);
 
 		return convertPatternGroupToTask(base, positive[base], fullNegative, dynamic);
 	});
+}
+
+/**
+ * Returns those negative patterns whose base paths includes positive base path.
+ */
+export function findLocalNegativePatterns(positiveBase: string, negative: PatternsGroup): Pattern[] {
+	return Object.keys(negative).reduce((collection, base) => {
+		if (base.startsWith(positiveBase)) {
+			collection.push(...negative[base]);
+		}
+
+		return collection;
+	}, [] as Pattern[]);
 }
 
 /**


### PR DESCRIPTION
### Links

* #107

### What is the purpose of this pull request?

This is fix for #107.

### What changes did you make? (Give an overview)

Negative patterns must include all negative patterns that match the first part of the base path from the positive pattern.