### PR TITLE
feat(index): Allow injection of own Reader implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,12 @@ import { Pattern } from './types/patterns';
 /**
  * Synchronous API.
  */
-export function sync(source: Pattern | Pattern[], opts?: IPartialOptions): EntryItem[] {
-	const works = getWorks<EntryItem[]>(source, ReaderSync, opts);
+export function sync(
+	source: Pattern | Pattern[],
+	opts?: IPartialOptions,
+	_Reader: new (options: IOptions) => Reader<EntryItem[]> = ReaderSync
+): EntryItem[] {
+	const works = getWorks<EntryItem[]>(source, _Reader, opts);
 
 	return arrayUtils.flatten(works);
 }
@@ -27,8 +31,12 @@ export function sync(source: Pattern | Pattern[], opts?: IPartialOptions): Entry
 /**
  * Asynchronous API.
  */
-export function async(source: Pattern | Pattern[], opts?: IPartialOptions): Promise<EntryItem[]> {
-	const works = getWorks<Promise<EntryItem[]>>(source, ReaderAsync, opts);
+export function async(
+	source: Pattern | Pattern[],
+	opts?: IPartialOptions,
+	_Reader: new (options: IOptions) => Reader<Promise<EntryItem[]>> = ReaderAsync
+): Promise<EntryItem[]> {
+	const works = getWorks<Promise<EntryItem[]>>(source, _Reader, opts);
 
 	return Promise.all(works).then(arrayUtils.flatten);
 }
@@ -36,8 +44,12 @@ export function async(source: Pattern | Pattern[], opts?: IPartialOptions): Prom
 /**
  * Stream API.
  */
-export function stream(source: Pattern | Pattern[], opts?: IPartialOptions): NodeJS.ReadableStream {
-	const works = getWorks<NodeJS.ReadableStream>(source, ReaderStream, opts);
+export function stream(
+	source: Pattern | Pattern[],
+	opts?: IPartialOptions,
+	_Reader: new (options: IOptions) => Reader<NodeJS.ReadableStream> = ReaderStream
+): NodeJS.ReadableStream {
+	const works = getWorks<NodeJS.ReadableStream>(source, _Reader, opts);
 
 	return merge2(works);
 }

--- a/src/tests/smoke/smoke.ts
+++ b/src/tests/smoke/smoke.ts
@@ -30,7 +30,7 @@ export interface ISmokeTest {
 	reason?: string;
 }
 
-type MochaDefinition = (desc: string, cb: (this: Mocha.ITestCallbackContext) => void) => void;
+type MochaDefinition = (desc: string, cb: (this: Mocha.Context) => void) => void;
 type DebugCompareTestMarker = '+' | '-';
 
 /**


### PR DESCRIPTION
### What is the purpose of this pull request?

I need the possibility to use my own FS Adapter implementation.

### What changes did you make? (Give an overview)

I slightly modified the public API. There is now the option to inject your own `Reader` implementation.

Additionally I fixed a linter error: `ERROR: 33:56  deprecation  ITestCallbackContext is deprecated: use 'Mocha.Context' instead.`