### PR TITLE
fix(ignore): ignore patterns which base path includes in source pattern base path

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -199,7 +199,7 @@ describe('Managers → Task', () => {
 	});
 
 	describe('.findLocalNegativePatterns', () => {
-		it('should retrun empty array for empty pattern group', () => {
+		it('should return empty array for empty pattern group', () => {
 			const expected: Pattern[] = [];
 
 			const actual = manager.findLocalNegativePatterns('base', {});
@@ -222,6 +222,16 @@ describe('Managers → Task', () => {
 
 			const actual = manager.findLocalNegativePatterns('base', {
 				'base/nested': ['base/nested/*']
+			});
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should return the pattern group when the positive base path is partial matched', () => {
+			const expected: Pattern[] = ['base/*'];
+
+			const actual = manager.findLocalNegativePatterns('base/nested', {
+				base: ['base/*']
 			});
 
 			assert.deepEqual(actual, expected);

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -97,11 +97,11 @@ export function convertPatternGroupsToTasks(positive: PatternsGroup, negative: P
 }
 
 /**
- * Returns those negative patterns whose base paths includes positive base path.
+ * Returns those negative patterns whose base paths includes positive base path or positive base path includes base paths.
  */
 export function findLocalNegativePatterns(positiveBase: string, negative: PatternsGroup): Pattern[] {
 	return Object.keys(negative).reduce((collection, base) => {
-		if (base.startsWith(positiveBase)) {
+		if (base.startsWith(positiveBase) || positiveBase.startsWith(base)) {
 			collection.push(...negative[base]);
 		}
 


### PR DESCRIPTION
### What is the purpose of this pull request?
Fix bug related to incorrect ignoring patterns.

Example:
```
var fg = require('fast-glob');
fg('fixtures/first/**/*.md', {ignore: ['fixtures/**/*.md']}).then(console.log)
```

Get result:
```
[ 'fixtures/first/file.md',
  'fixtures/first/nested/file.md',
  'fixtures/first/nested/directory/file.md' ]
```

Expected result:
```
[]
```

### What changes did you make? (Give an overview)
I fixed method `findLocalNegativePatterns` which should not only check that base path of ignore pattern includes base path of source pattern but also vice versa.