### PR TITLE
ISSUE-113: Trying to exclude entries by absolute negative patterns

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -47,9 +47,9 @@ describe('Managers → Task', () => {
 				{
 					base: 'a',
 					dynamic: false,
-					patterns: ['a/file.json', '!*.txt'],
+					patterns: ['a/file.json', '!b/*.md', '!*.txt'],
 					positive: ['a/file.json'],
-					negative: ['*.txt']
+					negative: ['b/*.md', '*.txt']
 				},
 				{
 					base: 'b',
@@ -100,9 +100,9 @@ describe('Managers → Task', () => {
 				{
 					base: 'a',
 					dynamic: true,
-					patterns: ['a/*'],
+					patterns: ['a/*', '!b/*.md'],
 					positive: ['a/*'],
-					negative: []
+					negative: ['b/*.md']
 				},
 				{
 					base: 'b',
@@ -259,47 +259,19 @@ describe('Managers → Task', () => {
 				negative: []
 			}];
 
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, {}, /* dynamic */ true);
+			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, [], /* dynamic */ true);
 
 			assert.deepStrictEqual(actual, expected);
 		});
 
-		it('should return one task without unused negative patterns', () => {
-			const expected: ITask[] = [{
-				base: 'a',
-				dynamic: true,
-				patterns: ['a/*'],
-				positive: ['a/*'],
-				negative: []
-			}];
-
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, { b: ['b/*'] }, /* dynamic */ true);
-
-			assert.deepStrictEqual(actual, expected);
-		});
-
-		it('should return one task with local and global negative patterns', () => {
-			const expected: ITask[] = [{
-				base: 'a',
-				dynamic: true,
-				patterns: ['a/*', '!a/*.txt', '!*.md'],
-				positive: ['a/*'],
-				negative: ['a/*.txt', '*.md']
-			}];
-
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'] }, { '.': ['*.md'], a: ['a/*.txt'] }, /* dynamic */ true);
-
-			assert.deepStrictEqual(actual, expected);
-		});
-
-		it('should return two tasks with negative patterns for only one task', () => {
+		it('should return two tasks with negative patterns', () => {
 			const expected: ITask[] = [
 				{
 					base: 'a',
 					dynamic: true,
-					patterns: ['a/*'],
+					patterns: ['a/*', '!b/*.md'],
 					positive: ['a/*'],
-					negative: []
+					negative: ['b/*.md']
 				},
 				{
 					base: 'b',
@@ -310,30 +282,7 @@ describe('Managers → Task', () => {
 				}
 			];
 
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'], b: ['b/*'] }, { b: ['b/*.md'] }, /* dynamic */ true);
-
-			assert.deepStrictEqual(actual, expected);
-		});
-
-		it('should return two tasks with local and global negative patterns', () => {
-			const expected: ITask[] = [
-				{
-					base: 'a',
-					dynamic: true,
-					patterns: ['a/*', '!*.md'],
-					positive: ['a/*'],
-					negative: ['*.md']
-				},
-				{
-					base: 'b',
-					dynamic: true,
-					patterns: ['b/*', '!*.md'],
-					positive: ['b/*'],
-					negative: ['*.md']
-				}
-			];
-
-			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'], b: ['b/*'] }, { '.': ['*.md'] }, /* dynamic */ true);
+			const actual = manager.convertPatternGroupsToTasks({ a: ['a/*'], b: ['b/*'] }, ['b/*.md'], /* dynamic */ true);
 
 			assert.deepStrictEqual(actual, expected);
 		});

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -35,7 +35,6 @@ export function generate(patterns: Pattern[], options: IOptions): ITask[] {
  */
 export function convertPatternsToTasks(positive: Pattern[], negative: Pattern[], dynamic: boolean): ITask[] {
 	const positivePatternsGroup = groupPatternsByBaseDirectory(positive);
-	const negativePatternsGroup = groupPatternsByBaseDirectory(negative);
 
 	// When we have a global group – there is no reason to divide the patterns into independent tasks.
 	// In this case, the global task covers the rest.
@@ -45,7 +44,7 @@ export function convertPatternsToTasks(positive: Pattern[], negative: Pattern[],
 		return [task];
 	}
 
-	return convertPatternGroupsToTasks(positivePatternsGroup, negativePatternsGroup, dynamic);
+	return convertPatternGroupsToTasks(positivePatternsGroup, negative, dynamic);
 }
 
 /**
@@ -85,14 +84,9 @@ export function groupPatternsByBaseDirectory(patterns: Pattern[]): PatternsGroup
 /**
  * Convert group of patterns to tasks.
  */
-export function convertPatternGroupsToTasks(positive: PatternsGroup, negative: PatternsGroup, dynamic: boolean): ITask[] {
-	const globalNegative = '.' in negative ? negative['.'] : [];
-
+export function convertPatternGroupsToTasks(positive: PatternsGroup, negative: Pattern[], dynamic: boolean): ITask[] {
 	return Object.keys(positive).map((base) => {
-		const localNegative = findLocalNegativePatterns(base, negative);
-		const fullNegative = localNegative.concat(globalNegative);
-
-		return convertPatternGroupToTask(base, positive[base], fullNegative, dynamic);
+		return convertPatternGroupToTask(base, positive[base], negative, dynamic);
 	});
 }
 

--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -5,6 +5,7 @@ import * as tests from '../../tests';
 import EntryFilter from './entry';
 
 import * as optionsManager from '../../managers/options';
+import * as pathUtil from '../../utils/path';
 
 import { FilterFunction } from '@mrmlnc/readdir-enhanced';
 import { IOptions, IPartialOptions } from '../../managers/options';
@@ -225,6 +226,49 @@ describe('Providers → Filters → Entry', () => {
 				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry(true /** dot */, false /** isSymbolicLink */);
+
+				const actual = filter(entry);
+
+				assert.ok(!actual);
+			});
+		});
+
+		describe('Filter by absolute negative patterns', () => {
+			it('should return true when `absolute` option is disabled', () => {
+				const filter = getFilter(['**/*'], []);
+
+				const entry = tests.getFileEntry(false /** dot */);
+
+				const actual = filter(entry);
+
+				assert.ok(actual);
+			});
+
+			it('should return true for file that no matched by negative pattern when `absolute` option is enabled', () => {
+				const filter = getFilter(['**/*'], ['*'], { absolute: true });
+
+				const entry = tests.getFileEntry(false /** dot */);
+
+				const actual = filter(entry);
+
+				assert.ok(actual);
+			});
+
+			it('should return false for file that excluded by negative pattern with globstar when `absolute` option is enabled', () => {
+				const filter = getFilter(['**/*'], ['**/*'], { absolute: true });
+
+				const entry = tests.getFileEntry(false /** dot */);
+
+				const actual = filter(entry);
+
+				assert.ok(!actual);
+			});
+
+			it('should return false for file that excluded by absolute negative patterns when `absolute` option is enabled', () => {
+				const negative = pathUtil.makeAbsolute(process.cwd(), '**');
+				const filter = getFilter(['**/*'], [negative], { absolute: true });
+
+				const entry = tests.getFileEntry(false /** dot */);
 
 				const actual = filter(entry);
 

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -41,7 +41,7 @@ export default class DeepFilter {
 			return false;
 		}
 
-		return this.isMatchToPatterns(entry, positiveRe) && !this.isMatchToPatterns(entry, negativeRe);
+		return this.isMatchToPatterns(entry.path, positiveRe) && !this.isMatchToPatterns(entry.path, negativeRe);
 	}
 
 	/**
@@ -78,7 +78,7 @@ export default class DeepFilter {
 	 * First, just trying to apply patterns to the path.
 	 * Second, trying to apply patterns to the path with final slash (need to micromatch to support «directory/**» patterns).
 	 */
-	private isMatchToPatterns(entry: Entry, patternsRe: PatternRe[]): boolean {
-		return patternUtils.matchAny(entry.path, patternsRe) || patternUtils.matchAny(entry.path + '/', patternsRe);
+	private isMatchToPatterns(filepath: string, patternsRe: PatternRe[]): boolean {
+		return patternUtils.matchAny(filepath, patternsRe) || patternUtils.matchAny(filepath + '/', patternsRe);
 	}
 }

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -1,5 +1,6 @@
 import micromatch = require('micromatch');
 
+import * as pathUtils from '../../utils/path';
 import * as patternUtils from '../../utils/pattern';
 
 import { IOptions } from '../../managers/options';
@@ -41,6 +42,10 @@ export default class DeepFilter {
 			return false;
 		}
 
+		if (this.isSkippedByAbsoluteNegativePatterns(entry, negativeRe)) {
+			return false;
+		}
+
 		return this.isMatchToPatterns(entry.path, positiveRe) && !this.isMatchToPatterns(entry.path, negativeRe);
 	}
 
@@ -70,6 +75,19 @@ export default class DeepFilter {
 	 */
 	private onlyDirectoryFilter(entry: Entry): boolean {
 		return this.options.onlyDirectories && !entry.isDirectory();
+	}
+
+	/**
+	 * Return true when `absolute` option is enabled and matched to the negative patterns.
+	 */
+	private isSkippedByAbsoluteNegativePatterns(entry: Entry, negativeRe: PatternRe[]): boolean {
+		if (!this.options.absolute) {
+			return false;
+		}
+
+		const fullpath = pathUtils.makeAbsolute(this.options.cwd, entry.path);
+
+		return this.isMatchToPatterns(fullpath, negativeRe);
 	}
 
 	/**

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -69,8 +69,7 @@ export default abstract class Reader<T> {
 	 */
 	public transform(entry: Entry): EntryItem {
 		if (this.options.absolute && !path.isAbsolute(entry.path)) {
-			entry.path = path.resolve(this.options.cwd, entry.path);
-			entry.path = pathUtil.normalize(entry.path);
+			entry.path = pathUtil.makeAbsolute(this.options.cwd, entry.path);
 		}
 
 		if (this.options.markDirectories && entry.isDirectory()) {

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -69,7 +69,7 @@ export default abstract class Reader<T> {
 	 */
 	public transform(entry: Entry): EntryItem {
 		if (this.options.absolute && !path.isAbsolute(entry.path)) {
-			entry.path = pathUtil.resolve(this.options.cwd, entry.path);
+			entry.path = path.resolve(this.options.cwd, entry.path);
 			entry.path = pathUtil.normalize(entry.path);
 		}
 

--- a/src/tests/smoke/absolute.smoke.ts
+++ b/src/tests/smoke/absolute.smoke.ts
@@ -40,9 +40,7 @@ smoke.suite('Smoke → Absolute (ignore)', [
 		pattern: 'fixtures/*',
 		ignore: path.join(process.cwd(), 'fixtures', '*'),
 		globOptions: { absolute: true },
-		fgOptions: { absolute: true },
-		broken: true,
-		issue: 113
+		fgOptions: { absolute: true }
 	},
 	{
 		pattern: 'fixtures/**',
@@ -50,15 +48,7 @@ smoke.suite('Smoke → Absolute (ignore)', [
 		globOptions: { absolute: true },
 		fgOptions: { absolute: true },
 		broken: true,
-		issue: 113
-	},
-	{
-		pattern: 'fixtures/**',
-		ignore: path.join(process.cwd(), 'fixtures', '**'),
-		globOptions: { absolute: true },
-		fgOptions: { absolute: true },
-		broken: true,
-		issue: 113
+		issue: 47
 	}
 ]);
 
@@ -104,26 +94,20 @@ smoke.suite('Smoke → Absolute (cwd & ignore)', [
 		ignore: path.join(process.cwd(), 'fixtures', '*'),
 		cwd: 'fixtures',
 		globOptions: { absolute: true },
-		fgOptions: { absolute: true },
-		broken: true,
-		issue: 113
+		fgOptions: { absolute: true }
 	},
 	{
 		pattern: '**',
 		ignore: path.join(process.cwd(), 'fixtures', '*'),
 		cwd: 'fixtures',
 		globOptions: { absolute: true },
-		fgOptions: { absolute: true },
-		broken: true,
-		issue: 113
+		fgOptions: { absolute: true }
 	},
 	{
 		pattern: '**',
 		ignore: path.join(process.cwd(), 'fixtures', '**'),
 		cwd: 'fixtures',
 		globOptions: { absolute: true },
-		fgOptions: { absolute: true },
-		broken: true,
-		issue: 113
+		fgOptions: { absolute: true }
 	}
 ]);

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -18,16 +18,6 @@ describe('Utils → Path', () => {
 		});
 	});
 
-	describe('.getDepth', () => {
-		it('should returns 4', () => {
-			const expected: number = 4;
-
-			const actual = util.getDepth('a/b/c/d.js');
-
-			assert.strictEqual(actual, expected);
-		});
-	});
-
 	describe('.resolve', () => {
 		it('should return resolved filepath', () => {
 			const expected = path.join(process.cwd(), 'file.md');

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as path from 'path';
 
 import * as util from './path';
 
@@ -22,6 +23,24 @@ describe('Utils → Path', () => {
 			const expected = 'directory/nested/file.md';
 
 			const actual = util.normalize('directory\\nested/file.md');
+
+			assert.strictEqual(actual, expected);
+		});
+	});
+
+	describe('.makeAbsolute', () => {
+		it('should return normalized filepath', () => {
+			const expected = '/something/file.md';
+
+			const actual = util.makeAbsolute(process.cwd(), '/something\\file.md');
+
+			assert.strictEqual(actual, expected);
+		});
+
+		it('should return normalized absolute filepath', () => {
+			const expected = path.join(process.cwd(), 'file.md').replace(/\\/g, '/');
+
+			const actual = util.makeAbsolute(process.cwd(), 'file.md');
 
 			assert.strictEqual(actual, expected);
 		});

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import * as path from 'path';
 
 import * as util from './path';
 
@@ -15,16 +14,6 @@ describe('Utils → Path', () => {
 			const actual = util.isDotDirectory('fixtures/.directory/directory');
 
 			assert.ok(!actual);
-		});
-	});
-
-	describe('.resolve', () => {
-		it('should return resolved filepath', () => {
-			const expected = path.join(process.cwd(), 'file.md');
-
-			const actual = util.resolve(process.cwd(), 'file.md');
-
-			assert.strictEqual(actual, expected);
 		});
 	});
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -8,13 +8,6 @@ export function isDotDirectory(filepath: string): boolean {
 }
 
 /**
- * Return naive depth of provided filepath.
- */
-export function getDepth(filepath: string): number {
-	return filepath.split('/').length;
-}
-
-/**
  * Return resolved a sequence of paths segments into an absolute path.
  */
 export function resolve(from: string, to: string): string {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -8,13 +8,6 @@ export function isDotDirectory(filepath: string): boolean {
 }
 
 /**
- * Return resolved a sequence of paths segments into an absolute path.
- */
-export function resolve(from: string, to: string): string {
-	return path.resolve(from, to);
-}
-
-/**
  * Convert a windows-like path to a unix-style path.
  */
 export function normalize(filepath: string): string {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -13,3 +13,16 @@ export function isDotDirectory(filepath: string): boolean {
 export function normalize(filepath: string): string {
 	return filepath.replace(/\\/g, '/');
 }
+
+/**
+ * Returns normalized absolute path of provided filepath.
+ */
+export function makeAbsolute(cwd: string, filepath: string): string {
+	if (path.isAbsolute(filepath)) {
+		return normalize(filepath);
+	}
+
+	const fullpath = path.resolve(cwd, filepath);
+
+	return normalize(fullpath);
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

This is fix for #113.

### What changes did you make? (Give an overview)

0. Now we apply all negative patterns to each task.
1. We trying to exclude entries by absolute negative patterns when `absolute` options is enabled (in this case we `resolve` absolute path to the entry and them apply negative patterns).
