### PR TITLE
FG-140: Correct way to handle all error events for stream mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import merge2 = require('merge2');
-
 import * as optionsManager from './managers/options';
 import * as taskManager from './managers/tasks';
 
@@ -9,6 +7,7 @@ import ReaderStream from './providers/reader-stream';
 import ReaderSync from './providers/reader-sync';
 
 import * as arrayUtils from './utils/array';
+import * as streamUtils from './utils/stream';
 
 import { IOptions, IPartialOptions } from './managers/options';
 import { ITask } from './managers/tasks';
@@ -49,7 +48,7 @@ export function stream(source: Pattern | Pattern[], opts?: IPartialOptions): Nod
 
 	const works = getWorks<NodeJS.ReadableStream>(source, ReaderStream, opts);
 
-	return merge2(works);
+	return streamUtils.merge(works);
 }
 
 /**

--- a/src/providers/reader-stream.ts
+++ b/src/providers/reader-stream.ts
@@ -38,7 +38,7 @@ export default class ReaderStream extends Reader<NodeJS.ReadableStream> {
 		const readable: NodeJS.ReadableStream = this.api(root, task, options);
 
 		return readable
-			.once('error', (err) => this.isEnoentCodeError(err) ? null : transform.emit('error', err))
+			.on('error', (err) => this.isEnoentCodeError(err) ? null : transform.emit('error', err))
 			.pipe(transform);
 	}
 

--- a/src/utils/stream.spec.ts
+++ b/src/utils/stream.spec.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+import * as stream from 'stream';
+
+import * as util from './stream';
+
+describe('Utils → Stream', () => {
+	describe('.merge', () => {
+		it('should merge two streams into one stream', () => {
+			const first = new stream.PassThrough();
+			const second = new stream.PassThrough();
+
+			const expected = 2;
+
+			const mergedStream = util.merge([first, second]);
+
+			const actual = mergedStream.listenerCount('close');
+
+			assert.strictEqual(actual, expected);
+		});
+
+		it('should propagate errors into merged stream', (done) => {
+			const first = new stream.PassThrough();
+			const second = new stream.PassThrough();
+
+			const expected = [1, 2, 3];
+
+			const mergedStream = util.merge([first, second]);
+
+			const actual: number[] = [];
+
+			mergedStream.on('error', (err) => actual.push(err));
+
+			mergedStream.on('finish', () => {
+				assert.deepStrictEqual(actual, expected);
+
+				done();
+			});
+
+			first.emit('error', 1);
+			second.emit('error', 2);
+			mergedStream.emit('error', 3);
+		});
+	});
+});

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,0 +1,14 @@
+import merge2 = require('merge2');
+
+/**
+ * Merge multiple streams and propagate their errors into one stream in parallel.
+ */
+export function merge(streams: NodeJS.ReadableStream[]): NodeJS.ReadableStream {
+	const mergedStream = merge2(streams);
+
+	streams.forEach((stream) => {
+		stream.on('error', (err) => mergedStream.emit('error', err));
+	});
+
+	return mergedStream;
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

This is fir fox issue #140.

### What changes did you make? (Give an overview)

When reading directories, the readable stream is not closed after
the first error. This is valid behavior because errors can occur while
reading the directory. For example, while reading a directory, another
process can delete it.

* Previously, we could only handle the first error. After the first error,
the process crashed due to an unhandled exception. Now we will absorb
all errors from the readable stream.

* Previously, we did not propagate errors to the merged stream.
