### PR TITLE
ISSUE-153: remove options with double-negation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Enable expansion of brace patterns.
 
 Enable matching with globstars (`**`).
 
-#### extension
+#### extglob
 
   * Type: `boolean`
   * Default: `true`
@@ -326,7 +326,7 @@ Not fully, because `fast-glob` does not implement all options of `node-glob`. Se
 | `nounique`   | [`unique`](#unique) |
 | `nobrace`    | [`brace`](#brace) |
 | `noglobstar` | [`globstar`](#globstar) |
-| `noext`      | [`extension`](#extension) |
+| `noext`      | [`extglob`](#extglob) |
 | `nocase`     | [`case`](#case) |
 | `matchBase`  | [`matchbase`](#matchbase) |
 | `nodir`      | [`onlyFiles`](#onlyfiles) |

--- a/README.md
+++ b/README.md
@@ -222,61 +222,33 @@ Return absolute paths for matched entries.
 
 > :book: Note that you need to use this option if you want to use absolute negative patterns like `${__dirname}/*.md`.
 
-#### nobrace
-
-  * Type: `boolean`
-  * Default: `false`
-
-Disable expansion of brace patterns (`{a,b}`, `{1..3}`).
-
 #### brace
 
   * Type: `boolean`
   * Default: `true`
 
-The [`nobrace`](#nobrace) option without double-negation. This option has a higher priority then `nobrace`.
-
-#### noglobstar
-
-  * Type: `boolean`
-  * Default: `false`
-
-Disable matching with globstars (`**`).
+Enable expansion of brace patterns.
 
 #### globstar
 
   * Type: `boolean`
   * Default: `true`
 
-The [`noglobstar`](#noglobstar) option without double-negation. This option has a higher priority then `noglobstar`.
-
-#### noext
-
-  * Type: `boolean`
-  * Default: `false`
-
-Disable extglob support (patterns like `+(a|b)`), so that extglobs are regarded as literal characters.
+Enable matching with globstars (`**`).
 
 #### extension
 
   * Type: `boolean`
   * Default: `true`
 
-The [`noext`](#noext) option without double-negation. This option has a higher priority then `noext`.
-
-#### nocase
-
-  * Type: `boolean`
-  * Default: `false`
-
-Disable a case-insensitive regex for matching files.
+Enable extglob support, so that extglobs are regarded as literal characters.
 
 #### case
 
   * Type: `boolean`
   * Default: `true`
 
-The [`nocase`](#nocase) option without double-negation. This option has a higher priority then `nocase`.
+Enable a case-insensitive regex for matching files.
 
 #### matchBase
 
@@ -352,10 +324,10 @@ Not fully, because `fast-glob` does not implement all options of `node-glob`. Se
 | `mark`       | [`markDirectories`](#markdirectories) |
 | `nosort`     | – |
 | `nounique`   | [`unique`](#unique) |
-| `nobrace`    | [`nobrace`](#nobrace) or [`brace`](#brace) |
-| `noglobstar` | [`noglobstar`](#noglobstar) or [`globstar`](#globstar) |
-| `noext`      | [`noext`](#noext) or [`extension`](#extension) |
-| `nocase`     | [`nocase`](#nocase) or [`case`](#case) |
+| `nobrace`    | [`brace`](#brace) |
+| `noglobstar` | [`globstar`](#globstar) |
+| `noext`      | [`extension`](#extension) |
+| `nocase`     | [`case`](#case) |
 | `matchBase`  | [`matchbase`](#matchbase) |
 | `nodir`      | [`onlyFiles`](#onlyfiles) |
 | `ignore`     | [`ignore`](#ignore) |

--- a/src/managers/options.spec.ts
+++ b/src/managers/options.spec.ts
@@ -17,7 +17,7 @@ function getOptions(options?: manager.IPartialOptions): manager.IOptions {
 		absolute: false,
 		brace: true,
 		globstar: true,
-		extension: true,
+		extglob: true,
 		case: true,
 		matchBase: false,
 		transform: null,
@@ -74,11 +74,11 @@ describe('Managers → Options', () => {
 			});
 		});
 
-		describe('The «extension» option', () => {
-			it('should set false for the «extension» option if «extension» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ extension: false });
+		describe('The «extglob» option', () => {
+			it('should set false for the «extglob» option if «extglob» option is enabled', () => {
+				const expected: manager.IOptions = getOptions({ extglob: false });
 
-				const actual = manager.prepare({ extension: false });
+				const actual = manager.prepare({ extglob: false });
 
 				assert.deepStrictEqual(actual, expected);
 			});

--- a/src/managers/options.spec.ts
+++ b/src/managers/options.spec.ts
@@ -15,13 +15,9 @@ function getOptions(options?: manager.IPartialOptions): manager.IOptions {
 		unique: true,
 		markDirectories: false,
 		absolute: false,
-		nobrace: false,
 		brace: true,
-		noglobstar: false,
 		globstar: true,
-		noext: false,
 		extension: true,
-		nocase: false,
 		case: true,
 		matchBase: false,
 		transform: null,
@@ -59,14 +55,6 @@ describe('Managers → Options', () => {
 		});
 
 		describe('The «brace» option', () => {
-			it('should set false for the «brace» option if «nobrace» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ brace: false, nobrace: true });
-
-				const actual = manager.prepare({ nobrace: true });
-
-				assert.deepStrictEqual(actual, expected);
-			});
-
 			it('should set false for the «brace» option if «brace» option is disabled', () => {
 				const expected: manager.IOptions = getOptions({ brace: false });
 
@@ -74,25 +62,9 @@ describe('Managers → Options', () => {
 
 				assert.deepStrictEqual(actual, expected);
 			});
-
-			it('should set true for the «brace» option if «brace» and «nobrace» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ brace: true, nobrace: true });
-
-				const actual = manager.prepare({ brace: true, nobrace: true });
-
-				assert.deepStrictEqual(actual, expected);
-			});
 		});
 
 		describe('The «globstar» option', () => {
-			it('should set false for the «globstar» option if «noglobstar» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ globstar: false, noglobstar: true });
-
-				const actual = manager.prepare({ noglobstar: true });
-
-				assert.deepStrictEqual(actual, expected);
-			});
-
 			it('should set false for the «globstar» option if «globstar» option is disabled', () => {
 				const expected: manager.IOptions = getOptions({ globstar: false });
 
@@ -100,25 +72,9 @@ describe('Managers → Options', () => {
 
 				assert.deepStrictEqual(actual, expected);
 			});
-
-			it('should set true for the «globstar» option if «globstar» and «noglobstar» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ globstar: true, noglobstar: true });
-
-				const actual = manager.prepare({ globstar: true, noglobstar: true });
-
-				assert.deepStrictEqual(actual, expected);
-			});
 		});
 
 		describe('The «extension» option', () => {
-			it('should set false for the «extension» option if «noext» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ extension: false, noext: true });
-
-				const actual = manager.prepare({ noext: true });
-
-				assert.deepStrictEqual(actual, expected);
-			});
-
 			it('should set false for the «extension» option if «extension» option is enabled', () => {
 				const expected: manager.IOptions = getOptions({ extension: false });
 
@@ -126,37 +82,13 @@ describe('Managers → Options', () => {
 
 				assert.deepStrictEqual(actual, expected);
 			});
-
-			it('should set true for the «extension» option if «extension» and «noext» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ extension: true, noext: true });
-
-				const actual = manager.prepare({ extension: true, noext: true });
-
-				assert.deepStrictEqual(actual, expected);
-			});
 		});
 
 		describe('The «case» option', () => {
-			it('should set false for the «case» option if «nocase» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ case: false, nocase: true });
-
-				const actual = manager.prepare({ nocase: true });
-
-				assert.deepStrictEqual(actual, expected);
-			});
-
 			it('should set false for the «case» option if «case» option is disabled', () => {
 				const expected: manager.IOptions = getOptions({ case: false });
 
 				const actual = manager.prepare({ case: false });
-
-				assert.deepStrictEqual(actual, expected);
-			});
-
-			it('should set true for the «extension» option if «case» and «nocase» option is enabled', () => {
-				const expected: manager.IOptions = getOptions({ case: true, nocase: true });
-
-				const actual = manager.prepare({ case: true, nocase: true });
 
 				assert.deepStrictEqual(actual, expected);
 			});

--- a/src/managers/options.ts
+++ b/src/managers/options.ts
@@ -61,7 +61,7 @@ export interface IOptions<T = EntryItem> {
 	/**
 	 * Enable extglob support, so that extglobs are regarded as literal characters.
 	 */
-	extension: boolean;
+	extglob: boolean;
 	/**
 	 * Enable a case-insensitive regex for matching files.
 	 */
@@ -94,7 +94,7 @@ export function prepare(options?: IPartialOptions): IOptions {
 		absolute: false,
 		brace: true,
 		globstar: true,
-		extension: true,
+		extglob: true,
 		case: true,
 		matchBase: false,
 		transform: null,
@@ -108,7 +108,7 @@ export function prepare(options?: IPartialOptions): IOptions {
 	if (options) {
 		opts.brace = ('brace' in options ? options.brace : opts.brace) as boolean;
 		opts.globstar = ('globstar' in options ? options.globstar : opts.globstar) as boolean;
-		opts.extension = ('extension' in options ? options.extension : opts.extension) as boolean;
+		opts.extglob = ('extglob' in options ? options.extglob : opts.extglob) as boolean;
 		opts.case = ('case' in options ? options.case : opts.case) as boolean;
 	}
 

--- a/src/managers/options.ts
+++ b/src/managers/options.ts
@@ -51,33 +51,17 @@ export interface IOptions<T = EntryItem> {
 	 */
 	absolute: boolean;
 	/**
-	 * Disable expansion of brace patterns.
-	 */
-	nobrace: boolean;
-	/**
 	 * Enable expansion of brace patterns.
 	 */
 	brace: boolean;
-	/**
-	 * Disable matching with globstars (`**`).
-	 */
-	noglobstar: boolean;
 	/**
 	 * Enable matching with globstars (`**`).
 	 */
 	globstar: boolean;
 	/**
-	 * Disable extglob support, so that extglobs are regarded as literal characters.
-	 */
-	noext: boolean;
-	/**
 	 * Enable extglob support, so that extglobs are regarded as literal characters.
 	 */
 	extension: boolean;
-	/**
-	 * Disable a case-insensitive regex for matching files.
-	 */
-	nocase: boolean;
 	/**
 	 * Enable a case-insensitive regex for matching files.
 	 */
@@ -96,7 +80,7 @@ export interface IOptions<T = EntryItem> {
 export type IPartialOptions<T = EntryItem> = Partial<IOptions<T>>;
 
 export function prepare(options?: IPartialOptions): IOptions {
-	const opts = {
+	const opts: IOptions = {
 		cwd: process.cwd(),
 		deep: true,
 		ignore: [],
@@ -108,13 +92,9 @@ export function prepare(options?: IPartialOptions): IOptions {
 		unique: true,
 		markDirectories: false,
 		absolute: false,
-		nobrace: false,
 		brace: true,
-		noglobstar: false,
 		globstar: true,
-		noext: false,
 		extension: true,
-		nocase: false,
 		case: true,
 		matchBase: false,
 		transform: null,
@@ -124,11 +104,6 @@ export function prepare(options?: IPartialOptions): IOptions {
 	if (opts.onlyDirectories) {
 		opts.onlyFiles = false;
 	}
-
-	opts.brace = !opts.nobrace;
-	opts.globstar = !opts.noglobstar;
-	opts.extension = !opts.noext;
-	opts.case = !opts.nocase;
 
 	if (options) {
 		opts.brace = ('brace' in options ? options.brace : opts.brace) as boolean;

--- a/src/providers/reader.ts
+++ b/src/providers/reader.ts
@@ -58,7 +58,7 @@ export default abstract class Reader<T> {
 			dot: this.options.dot,
 			nobrace: !this.options.brace,
 			noglobstar: !this.options.globstar,
-			noext: !this.options.extension,
+			noext: !this.options.extglob,
 			nocase: !this.options.case,
 			matchBase: this.options.matchBase
 		};


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for issue #153.

### What changes did you make? (Give an overview)

* Remove `nobrace`, `noglobstar`, `noext` and `nocase` options.
* The `extension` option was renamed to `extglob`.
