### PR TITLE
Set is-glob strict to false to match micromatch/glob behavior 

### DIFF
--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -25,6 +25,12 @@ describe('Utils → Pattern', () => {
 			assert.ok(actual);
 		});
 
+		it('should return true for dynamic pattern with question mark glob', () => {
+			const actual = util.isDynamicPattern('?');
+
+			assert.ok(actual);
+		});
+
 		it('should return false for static pattern', () => {
 			const actual = util.isDynamicPattern('dir');
 

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -19,7 +19,7 @@ export function isStaticPattern(pattern: Pattern): boolean {
  * Return true for pattern that looks like glob.
  */
 export function isDynamicPattern(pattern: Pattern): boolean {
-	return isGlob(pattern);
+	return isGlob(pattern, { strict: false });
 }
 
 /**


### PR DESCRIPTION
### What is the purpose of this pull request?
Setting *strict* option to false will make `is-glob` pattern matching more compatible with `micromatch`, `glob` libraries, which is [mentioned in is-glob docs](https://github.com/micromatch/is-glob#option-strict).

In some cases a valid pattern was not recognised as a glob one, example in linked issue.

### What changes did you make? (Give an overview)
Set `is-glob` *strict* option to false.

Fix https://github.com/mrmlnc/fast-glob/issues/174
