### PR TITLE
ISSUE-163: patterns can only use forward-slash as a path separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,32 @@ fg.sync(['**/*.md'], { ignore: '**/second/**' }); // ['first/file.txt']
 
 You have to understand that if you write the pattern to exclude directories, then the directory will not be read under any circumstances.
 
+## How to write patterns on Windows?
+
+Always use forward-slashes in glob expressions (patterns and `ignore` option). Use backslashes for escaping characters. With the `cwd` option use a convenient format.
+
+**Bad**
+
+```ts
+[
+	'directory\\*',
+	path.join(process.cwd(), '**')
+]
+```
+
+**Good**
+
+```ts
+[
+	'directory/*',
+	path.join(process.cwd(), '**').replace(/\\/g, '/')
+]
+```
+
+> :book: Use the [`normalize-path`](https://www.npmjs.com/package/normalize-path) or the [`unixify`](https://www.npmjs.com/package/unixify) package to convert Windows-style path to a Unix-style path.
+
+Read more about [matching with backslashes](https://github.com/micromatch/micromatch#backslashes).
+
 ## Compatible with `node-glob`?
 
 Not fully, because `fast-glob` does not implement all options of `node-glob`. See table below.

--- a/src/adapters/fs.spec.ts
+++ b/src/adapters/fs.spec.ts
@@ -52,9 +52,10 @@ describe('Adapters → FileSystem', () => {
 		it('should return created entry', () => {
 			const adapter = getAdapter();
 
-			const actual = adapter.makeEntry(tests.getFileEntry(), 'base/file.json');
+			const filepath = path.join('base', 'file.json');
+			const actual = adapter.makeEntry(tests.getFileEntry(), filepath);
 
-			assert.strictEqual(actual.path, 'base/file.json');
+			assert.strictEqual(actual.path, filepath);
 			assert.strictEqual(actual.depth, 2);
 		});
 

--- a/src/adapters/fs.ts
+++ b/src/adapters/fs.ts
@@ -24,7 +24,7 @@ export default abstract class FileSystem<T> {
 	 */
 	public makeEntry(stat: fs.Stats, pattern: Pattern): Entry {
 		(stat as Entry).path = pattern;
-		(stat as Entry).depth = pattern.split('/').length;
+		(stat as Entry).depth = pattern.split(path.sep).length;
 
 		return stat as Entry;
 	}

--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -7,22 +7,6 @@ import { Task } from './tasks';
 
 describe('Managers → Task', () => {
 	describe('.generate', () => {
-		it('should return task with windows-like patterns', () => {
-			const settings = new Settings();
-
-			const expected: Task[] = [{
-				base: 'a',
-				dynamic: true,
-				patterns: ['a/*'],
-				positive: ['a/*'],
-				negative: []
-			}];
-
-			const actual = manager.generate(['a\\*'], settings);
-
-			assert.deepStrictEqual(actual, expected);
-		});
-
 		it('should return task with negative patterns from «ignore» option', () => {
 			const settings = new Settings({ ignore: ['*.txt'] });
 

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -14,11 +14,8 @@ export interface Task {
  * Generate tasks based on parent directory of each pattern.
  */
 export function generate(patterns: Pattern[], settings: Settings): Task[] {
-	const unixPatterns = patterns.map(utils.pattern.unixifyPattern);
-	const unixIgnore = settings.ignore.map(utils.pattern.unixifyPattern);
-
-	const positivePatterns = getPositivePatterns(unixPatterns);
-	const negativePatterns = getNegativePatternsAsPositive(unixPatterns, unixIgnore);
+	const positivePatterns = getPositivePatterns(patterns);
+	const negativePatterns = getNegativePatternsAsPositive(patterns, settings.ignore);
 
 	const staticPatterns = positivePatterns.filter(utils.pattern.isStaticPattern);
 	const dynamicPatterns = positivePatterns.filter(utils.pattern.isDynamicPattern);

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as path from 'path';
 
 import Settings, { Options } from '../../settings';
 import * as tests from '../../tests';
@@ -42,7 +43,7 @@ describe('Providers → Filters → Deep', () => {
 				const filter = getFilter(['fixtures/**'], [], { deep: 1 });
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/one/two/three'
+					path: path.join('fixtures', 'one', 'two', 'three')
 				});
 
 				const actual = filter(entry);
@@ -54,7 +55,7 @@ describe('Providers → Filters → Deep', () => {
 				const filter = getFilter(['fixtures/**'], [], { deep: 1 });
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/one/two'
+					path: path.join('fixtures', 'one', 'two')
 				});
 
 				const actual = filter(entry);
@@ -66,7 +67,7 @@ describe('Providers → Filters → Deep', () => {
 				const filter = getFilter(['fixtures/**'], [], { deep: 2 });
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/one/two'
+					path: path.join('fixtures', 'one', 'two')
 				});
 
 				const actual = filter(entry);
@@ -90,7 +91,7 @@ describe('Providers → Filters → Deep', () => {
 				const filter = getFilter(['fixtures/*/*/*'], []);
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/one/two'
+					path: path.join('fixtures', 'one', 'two')
 				});
 
 				const actual = filter(entry);
@@ -102,7 +103,7 @@ describe('Providers → Filters → Deep', () => {
 				const filter = getFilter(['fixtures/*'], []);
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/one/two/three/four'
+					path: path.join('fixtures', 'one', 'two', 'three', 'four')
 				});
 
 				const actual = filter(entry);
@@ -142,7 +143,7 @@ describe('Providers → Filters → Deep', () => {
 				const filter = getFilter(['**/*'], [], { onlyFiles: false, dot: true });
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/.directory'
+					path: path.join('fixtures', '.directory')
 				});
 
 				const actual = filter(entry);
@@ -154,7 +155,7 @@ describe('Providers → Filters → Deep', () => {
 				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/.directory'
+					path: path.join('fixtures', '.directory')
 				});
 
 				const actual = filter(entry);

--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as path from 'path';
 
 import Settings, { Options } from '../../settings';
 import * as tests from '../../tests';
@@ -191,7 +192,7 @@ describe('Providers → Filters → Entry', () => {
 				const filter = getFilter(['**/*'], [], { onlyFiles: false, dot: true });
 
 				const entry = tests.getFileEntry({
-					path: 'fixtures/.file.txt'
+					path: path.join('fixtures', '.file.txt')
 				});
 
 				const actual = filter(entry);
@@ -203,7 +204,7 @@ describe('Providers → Filters → Entry', () => {
 				const filter = getFilter(['**/*'], [], { onlyFiles: false });
 
 				const entry = tests.getFileEntry({
-					path: 'fixtures/.file.txt'
+					path: path.join('fixtures', '.file.txt')
 				});
 
 				const actual = filter(entry);
@@ -215,7 +216,7 @@ describe('Providers → Filters → Entry', () => {
 				const filter = getFilter(['**/*'], [], { onlyFiles: false, dot: true });
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/.directory'
+					path: path.join('fixtures', '.directory')
 				});
 
 				const actual = filter(entry);
@@ -227,7 +228,7 @@ describe('Providers → Filters → Entry', () => {
 				const filter = getFilter(['**/*'], []);
 
 				const entry = tests.getDirectoryEntry({
-					path: 'fixtures/.directory'
+					path: path.join('fixtures', '.directory')
 				});
 
 				const actual = filter(entry);
@@ -268,7 +269,7 @@ describe('Providers → Filters → Entry', () => {
 			});
 
 			it('should return false for file that excluded by absolute negative patterns when `absolute` option is enabled', () => {
-				const negative = utils.path.makeAbsolute(process.cwd(), '**');
+				const negative = utils.path.makeAbsolute(process.cwd(), '**').replace(/\\/g, '/');
 				const filter = getFilter(['**/*'], [negative], { absolute: true });
 
 				const entry = tests.getFileEntry();

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 import Settings from '../../settings';
 import { Entry, EntryFilterFunction, MicromatchOptions, Pattern, PatternRe } from '../../types/index';
 import * as utils from '../../utils/index';
@@ -90,6 +92,6 @@ export default class EntryFilter {
 	 * Second, trying to apply patterns to the path with final slash (need to micromatch to support «directory/**» patterns).
 	 */
 	private isMatchToPatterns(filepath: string, patternsRe: PatternRe[]): boolean {
-		return utils.pattern.matchAny(filepath, patternsRe) || utils.pattern.matchAny(filepath + '/', patternsRe);
+		return utils.pattern.matchAny(filepath, patternsRe) || utils.pattern.matchAny(filepath + path.sep, patternsRe);
 	}
 }

--- a/src/providers/provider.spec.ts
+++ b/src/providers/provider.spec.ts
@@ -64,7 +64,6 @@ describe('Providers → Provider', () => {
 			});
 
 			assert.strictEqual(actual.basePath, '');
-			assert.strictEqual(actual.sep, '/');
 			assert.strictEqual(typeof actual.filter, 'function');
 			assert.strictEqual(typeof actual.deep, 'function');
 		});
@@ -81,7 +80,6 @@ describe('Providers → Provider', () => {
 			});
 
 			assert.strictEqual(actual.basePath, 'fixtures');
-			assert.strictEqual(actual.sep, '/');
 			assert.strictEqual(typeof actual.filter, 'function');
 			assert.strictEqual(typeof actual.deep, 'function');
 		});
@@ -124,7 +122,7 @@ describe('Providers → Provider', () => {
 				const entry = tests.getDirectoryEntry();
 
 				const fullpath = path.join(process.cwd(), 'fixtures/directory/');
-				const expected = utils.path.normalize(fullpath);
+				const expected = utils.path.unixify(fullpath);
 
 				const actual = provider.transform(entry);
 
@@ -160,7 +158,7 @@ describe('Providers → Provider', () => {
 				const entry = tests.getFileEntry();
 
 				const fullpath = path.join(process.cwd(), 'fixtures/file.txt');
-				const expected = utils.path.normalize(fullpath);
+				const expected = utils.path.unixify(fullpath);
 
 				const actual = provider.transform(entry);
 

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -39,8 +39,7 @@ export default abstract class Provider<T> {
 		return {
 			basePath: task.base === '.' ? '' : task.base,
 			filter: this.entryFilter.getFilter(task.positive, task.negative),
-			deep: this.deepFilter.getFilter(task.positive, task.negative),
-			sep: '/'
+			deep: this.deepFilter.getFilter(task.positive, task.negative)
 		};
 	}
 
@@ -67,8 +66,10 @@ export default abstract class Provider<T> {
 		}
 
 		if (this.settings.markDirectories && entry.isDirectory()) {
-			entry.path += '/';
+			entry.path += path.sep;
 		}
+
+		entry.path = utils.path.unixify(entry.path);
 
 		const item: EntryItem = this.settings.stats ? entry : entry.path;
 

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import * as stream from 'stream';
 
 import { Entry, EntryItem } from '../types/index';
@@ -34,8 +35,8 @@ interface FakeFsStatOptions {
 }
 
 class FakeEntry extends fs.Stats {
-	public path: string = this._options.path || 'fixtures/entry';
-	public depth: number = this.path.split('/').length - 2;
+	public path: string = this._options.path || path.join('fixtures', 'entry');
+	public depth: number = this.path.split(path.sep).length - 2;
 
 	constructor(private readonly _options: Partial<FakeFsStatOptions> = {}) {
 		super();
@@ -61,7 +62,7 @@ export function getEntry(options: Partial<FakeFsStatOptions> = {}): Entry {
 export function getFileEntry(options: Partial<FakeFsStatOptions> = {}): Entry {
 	return new FakeEntry({
 		isFile: true,
-		path: 'fixtures/file.txt',
+		path: path.join('fixtures', 'file.txt'),
 		...options
 	});
 }
@@ -69,7 +70,7 @@ export function getFileEntry(options: Partial<FakeFsStatOptions> = {}): Entry {
 export function getDirectoryEntry(options: Partial<FakeFsStatOptions> = {}): Entry {
 	return new FakeEntry({
 		isDirectory: true,
-		path: 'fixtures/directory',
+		path: path.join('fixtures', 'directory'),
 		...options
 	});
 }

--- a/src/tests/smoke/absolute.smoke.ts
+++ b/src/tests/smoke/absolute.smoke.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 
 import * as smoke from './smoke';
 
+const CWD = process.cwd().replace(/\\/g, '/');
+
 smoke.suite('Smoke → Absolute', [
 	{
 		pattern: 'fixtures/*',
@@ -38,13 +40,13 @@ smoke.suite('Smoke → Absolute (ignore)', [
 
 	{
 		pattern: 'fixtures/*',
-		ignore: path.join(process.cwd(), 'fixtures', '*'),
+		ignore: path.posix.join(CWD, 'fixtures', '*'),
 		globOptions: { absolute: true },
 		fgOptions: { absolute: true }
 	},
 	{
 		pattern: 'fixtures/**',
-		ignore: path.join(process.cwd(), 'fixtures', '*'),
+		ignore: path.posix.join(CWD, 'fixtures', '*'),
 		globOptions: { absolute: true },
 		fgOptions: { absolute: true },
 		broken: true,
@@ -91,21 +93,21 @@ smoke.suite('Smoke → Absolute (cwd & ignore)', [
 
 	{
 		pattern: '*',
-		ignore: path.join(process.cwd(), 'fixtures', '*'),
+		ignore: path.posix.join(CWD, 'fixtures', '*'),
 		cwd: 'fixtures',
 		globOptions: { absolute: true },
 		fgOptions: { absolute: true }
 	},
 	{
 		pattern: '**',
-		ignore: path.join(process.cwd(), 'fixtures', '*'),
+		ignore: path.posix.join(CWD, 'fixtures', '*'),
 		cwd: 'fixtures',
 		globOptions: { absolute: true },
 		fgOptions: { absolute: true }
 	},
 	{
 		pattern: '**',
-		ignore: path.join(process.cwd(), 'fixtures', '**'),
+		ignore: path.posix.join(CWD, 'fixtures', '**'),
 		cwd: 'fixtures',
 		globOptions: { absolute: true },
 		fgOptions: { absolute: true }

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -6,13 +6,15 @@ import * as util from './path';
 describe('Utils → Path', () => {
 	describe('.isDotDirectory', () => {
 		it('should return true for dot directory', () => {
-			const actual = util.isDotDirectory('fixtures/.directory');
+			const filepath = path.join('fixtures', '.directory');
+			const actual = util.isDotDirectory(filepath);
 
 			assert.ok(actual);
 		});
 
 		it('should return false for non-dot directory', () => {
-			const actual = util.isDotDirectory('fixtures/.directory/directory');
+			const filepath = path.join('fixtures', '.directory', 'directory');
+			const actual = util.isDotDirectory(filepath);
 
 			assert.ok(!actual);
 		});
@@ -22,23 +24,25 @@ describe('Utils → Path', () => {
 		it('should return path with converted slashes', () => {
 			const expected = 'directory/nested/file.md';
 
-			const actual = util.normalize('directory\\nested/file.md');
+			const actual = util.unixify('directory\\nested/file.md');
 
 			assert.strictEqual(actual, expected);
 		});
 	});
 
 	describe('.makeAbsolute', () => {
-		it('should return normalized filepath', () => {
-			const expected = '/something/file.md';
+		it('should return absolute filepath without changes', () => {
+			const filepath = path.resolve('something', 'file.md');
 
-			const actual = util.makeAbsolute(process.cwd(), '/something\\file.md');
+			const expected = filepath;
+
+			const actual = util.makeAbsolute(process.cwd(), filepath);
 
 			assert.strictEqual(actual, expected);
 		});
 
-		it('should return normalized absolute filepath', () => {
-			const expected = path.join(process.cwd(), 'file.md').replace(/\\/g, '/');
+		it('should return absolute filepath', () => {
+			const expected = path.join(process.cwd(), 'file.md');
 
 			const actual = util.makeAbsolute(process.cwd(), 'file.md');
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -10,7 +10,7 @@ export function isDotDirectory(filepath: string): boolean {
 /**
  * Convert a windows-like path to a unix-style path.
  */
-export function normalize(filepath: string): string {
+export function unixify(filepath: string): string {
 	return filepath.replace(/\\/g, '/');
 }
 
@@ -19,10 +19,8 @@ export function normalize(filepath: string): string {
  */
 export function makeAbsolute(cwd: string, filepath: string): string {
 	if (path.isAbsolute(filepath)) {
-		return normalize(filepath);
+		return filepath;
 	}
 
-	const fullpath = path.resolve(cwd, filepath);
-
-	return normalize(fullpath);
+	return path.resolve(cwd, filepath);
 }

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -32,16 +32,6 @@ describe('Utils → Pattern', () => {
 		});
 	});
 
-	describe('.unixifyPattern', () => {
-		it('should convert backslashes to forward slashes', () => {
-			const expected: Pattern = '**/*';
-
-			const actual = util.unixifyPattern('**\\*');
-
-			assert.strictEqual(actual, expected);
-		});
-	});
-
 	describe('.convertToPositivePattern', () => {
 		it('should returns converted positive pattern', () => {
 			const expected: Pattern = '*.js';

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -23,13 +23,6 @@ export function isDynamicPattern(pattern: Pattern): boolean {
 }
 
 /**
- * Convert a windows «path» to a unix-style «path».
- */
-export function unixifyPattern(pattern: Pattern): Pattern {
-	return pattern.replace(/\\/g, '/');
-}
-
-/**
  * Returns negative pattern as positive pattern.
  */
 export function convertToPositivePattern(pattern: Pattern): Pattern {


### PR DESCRIPTION
### What is the purpose of this pull request?

Previously, we replaced separators in patterns to a single form (forward-slashes),
which broke the behavior of user patterns in some cases.

Related to: #155, #163, #173.

### What changes did you make? (Give an overview)

After this commit:

* patterns should always be written using forward-slash;
* all paths inside this package use separators in accordance with the operating system;

