### PR TITLE
ISSUE-157: always resolve absolute filepath

### DIFF
--- a/src/providers/provider.spec.ts
+++ b/src/providers/provider.spec.ts
@@ -157,7 +157,21 @@ describe('Providers → Provider', () => {
 				const provider = getProvider({ absolute: true });
 				const entry = tests.getFileEntry();
 
-				const fullpath = path.join(process.cwd(), 'fixtures/file.txt');
+				const fullpath = path.join(process.cwd(), 'fixtures', 'file.txt');
+				const expected = utils.path.unixify(fullpath);
+
+				const actual = provider.transform(entry);
+
+				assert.strictEqual(actual, expected);
+			});
+
+			it('should transform event absolute filepath when option is provided', () => {
+				const provider = getProvider({ absolute: true });
+				const entry = tests.getFileEntry({
+					path: `${process.cwd()}/fixtures/../file.txt`
+				});
+
+				const fullpath = path.join(process.cwd(), 'file.txt');
 				const expected = utils.path.unixify(fullpath);
 
 				const actual = provider.transform(entry);

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -61,7 +61,7 @@ export default abstract class Provider<T> {
 	 * Returns transformed entry.
 	 */
 	public transform(entry: Entry): EntryItem {
-		if (this.settings.absolute && !path.isAbsolute(entry.path)) {
+		if (this.settings.absolute) {
 			entry.path = utils.path.makeAbsolute(this.settings.cwd, entry.path);
 		}
 

--- a/src/tests/smoke/absolute.smoke.ts
+++ b/src/tests/smoke/absolute.smoke.ts
@@ -21,6 +21,11 @@ smoke.suite('Smoke → Absolute', [
 		pattern: 'fixtures/**/*',
 		globOptions: { absolute: true },
 		fgOptions: { absolute: true }
+	},
+	{
+		pattern: 'fixtures/../*',
+		globOptions: { absolute: true },
+		fgOptions: { absolute: true }
 	}
 ]);
 

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -31,16 +31,6 @@ describe('Utils → Path', () => {
 	});
 
 	describe('.makeAbsolute', () => {
-		it('should return absolute filepath without changes', () => {
-			const filepath = path.resolve('something', 'file.md');
-
-			const expected = filepath;
-
-			const actual = util.makeAbsolute(process.cwd(), filepath);
-
-			assert.strictEqual(actual, expected);
-		});
-
 		it('should return absolute filepath', () => {
 			const expected = path.join(process.cwd(), 'file.md');
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -15,12 +15,8 @@ export function unixify(filepath: string): string {
 }
 
 /**
- * Returns normalized absolute path of provided filepath.
+ * Returns absolute path for provided filepath relative to cwd.
  */
 export function makeAbsolute(cwd: string, filepath: string): string {
-	if (path.isAbsolute(filepath)) {
-		return filepath;
-	}
-
 	return path.resolve(cwd, filepath);
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for issue #157.

### What changes did you make? (Give an overview)

The filepath can include `.` or `..` that must be resolved.
