### PR TITLE
ISSUE-172: Always mark patterns as dynamic with case-insensitive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,13 @@ Enable extglob support, so that extglobs are regarded as literal characters.
   * Type: `boolean`
   * Default: `true`
 
-Enable a case-insensitive regex for matching files.
+Enable a [case-sensitive](https://en.wikipedia.org/wiki/Case_sensitivity) mode for matching files.
+
+##### Examples
+
+* File System: `test/file.md`, `test/File.md`
+* Case-sensitive for `test/file.*` pattern: `test/file.md`
+* Case-insensitive for `test/file.*` pattern: `test/file.md`, `test/File.md`
 
 #### matchBase
 

--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -47,6 +47,31 @@ describe('Managers → Task', () => {
 
 			assert.deepStrictEqual(actual, expected);
 		});
+
+		it('should return only dynamic patterns when the `case` option is enabled', () => {
+			const settings = new Settings({ case: false });
+
+			const expected: Task[] = [
+				{
+					base: 'a',
+					dynamic: true,
+					patterns: ['a/file.json', '!b/*.md'],
+					positive: ['a/file.json'],
+					negative: ['b/*.md']
+				},
+				{
+					base: 'b',
+					dynamic: true,
+					patterns: ['b/*', '!b/*.md'],
+					positive: ['b/*'],
+					negative: ['b/*.md']
+				}
+			];
+
+			const actual = manager.generate(['a/file.json', 'b/*', '!b/*.md'], settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
 	});
 
 	describe('.convertPatternsToTasks', () => {

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -17,8 +17,12 @@ export function generate(patterns: Pattern[], settings: Settings): Task[] {
 	const positivePatterns = getPositivePatterns(patterns);
 	const negativePatterns = getNegativePatternsAsPositive(patterns, settings.ignore);
 
-	const staticPatterns = positivePatterns.filter(utils.pattern.isStaticPattern);
-	const dynamicPatterns = positivePatterns.filter(utils.pattern.isDynamicPattern);
+	/**
+	 * When the `case` option is disabled, all patterns must be marked as dynamic, because we cannot check filepath
+	 * directly (without read directory).
+	 */
+	const staticPatterns = !settings.case ? [] : positivePatterns.filter(utils.pattern.isStaticPattern);
+	const dynamicPatterns = !settings.case ? positivePatterns : positivePatterns.filter(utils.pattern.isDynamicPattern);
 
 	const staticTasks = convertPatternsToTasks(staticPatterns, negativePatterns, /* dynamic */ false);
 	const dynamicTasks = convertPatternsToTasks(dynamicPatterns, negativePatterns, /* dynamic */ true);


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for issue #172.

### What changes did you make? (Give an overview)

Always mark each pattern as dynamic when the `case` option is disabled (case-insensitive mode).
