### PR TITLE
ISSUE-163: Use `@nodelib/fs.walk` instead of `readdir-enhanced`

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ fg.sync(['(special-*file).txt']) // → [] for files: ['(special-*file).txt']
 Refers to Bash. You need to escape special characters:
 
 ```js
-fg.sync(['\(special-*file\).txt']) // → ['(special-*file).txt']
+fg.sync(['\\(special-*file\\).txt']) // → ['(special-*file).txt']
 ```
 
 Read more about [«Matching special characters as literals»](https://github.com/micromatch/picomatch#matching-special-characters-as-literals).

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "bench": "npm run bench-async && npm run bench-sync",
     "bench-async": "npm run bench-async-flatten && npm run bench-async-deep",
     "bench-sync": "npm run bench-sync-flatten && npm run bench-sync-deep",
-    "bench-async-flatten": "node ./out/benchmark --type async --pattern *",
-    "bench-async-deep": "node ./out/benchmark --type async --pattern **",
-    "bench-sync-flatten": "node ./out/benchmark --type sync --pattern *",
-    "bench-sync-deep": "node ./out/benchmark --type sync --pattern **"
+    "bench-async-flatten": "node ./out/benchmark --type async --pattern \"*\"",
+    "bench-async-deep": "node ./out/benchmark --type async --pattern \"**\"",
+    "bench-sync-flatten": "node ./out/benchmark --type sync --pattern \"*\"",
+    "bench-sync-deep": "node ./out/benchmark --type sync --pattern \"**\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@mrmlnc/readdir-enhanced": "^2.2.1",
     "@nodelib/fs.stat": "^2.0.0",
-    "glob-parent": "^3.1.0",
+    "glob-parent": "^5.0.0",
     "is-glob": "^4.0.0",
     "merge2": "^1.2.3",
     "micromatch": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "implementation"
   ],
   "devDependencies": {
+    "@nodelib/fs.macchiato": "^1.0.0",
     "@types/compute-stdev": "^1.0.0",
     "@types/easy-table": "^0.0.32",
     "@types/execa": "^0.9.0",
@@ -48,6 +49,7 @@
   "dependencies": {
     "@mrmlnc/readdir-enhanced": "^2.2.1",
     "@nodelib/fs.stat": "^2.0.0",
+    "@nodelib/fs.walk": "^1.1.0",
     "glob-parent": "^5.0.0",
     "is-glob": "^4.0.0",
     "merge2": "^1.2.3",

--- a/src/adapters/fs-stream.spec.ts
+++ b/src/adapters/fs-stream.spec.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 
+import { Stats } from '@nodelib/fs.macchiato';
+
 import Settings from '../settings';
 import { Entry, Pattern } from '../types/index';
 import FileSystemStream from './fs-stream';
@@ -11,7 +13,7 @@ class FileSystemStreamFake extends FileSystemStream {
 	}
 
 	public getStat(): Promise<fs.Stats> {
-		return getStats(1);
+		return Promise.resolve(new Stats());
 	}
 }
 
@@ -25,12 +27,8 @@ class FileSystemStreamThrowStatError extends FileSystemStreamFake {
 			return Promise.reject(new Error('something'));
 		}
 
-		return getStats(1);
+		return Promise.resolve(new Stats());
 	}
-}
-
-function getStats(uid: number): Promise<fs.Stats> {
-	return Promise.resolve({ uid } as fs.Stats);
 }
 
 function getAdapter(): FileSystemStreamFake {
@@ -91,15 +89,10 @@ describe('Adapters → FileSystemStream', () => {
 		it('should return created entry', async () => {
 			const adapter = getAdapter();
 
-			const expected: Entry = {
-				path: 'pattern',
-				depth: 1,
-				uid: 1
-			} as Entry;
-
 			const actual = await adapter.getEntry('filepath', 'pattern');
 
-			assert.deepStrictEqual(actual, expected);
+			assert.strictEqual((actual as Entry).name, 'pattern');
+			assert.strictEqual((actual as Entry).path, 'pattern');
 		});
 
 		it('should return null when lstat throw error', async () => {

--- a/src/adapters/fs-sync.spec.ts
+++ b/src/adapters/fs-sync.spec.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 
+import { Stats } from '@nodelib/fs.macchiato';
+
 import Settings from '../settings';
 import { Entry, Pattern } from '../types/index';
 import FileSystemSync from './fs-sync';
@@ -11,7 +13,7 @@ class FileSystemSyncFake extends FileSystemSync {
 	}
 
 	public getStat(): fs.Stats {
-		return getStats(1);
+		return new Stats();
 	}
 }
 
@@ -28,12 +30,8 @@ class FileSystemSyncThrowStatError extends FileSystemSyncFake {
 			throw new Error('Something');
 		}
 
-		return getStats(1);
+		return new Stats();
 	}
-}
-
-function getStats(uid: number): fs.Stats {
-	return { uid } as fs.Stats;
 }
 
 function getAdapter(): FileSystemSyncFake {
@@ -85,15 +83,10 @@ describe('Adapters → FileSystemSync', () => {
 		it('should return created entry', () => {
 			const adapter = getAdapter();
 
-			const expected: Entry = {
-				path: 'pattern',
-				depth: 1,
-				uid: 1
-			} as Entry;
-
 			const actual = adapter.getEntry('filepath', 'pattern');
 
-			assert.deepStrictEqual(actual, expected);
+			assert.strictEqual((actual as Entry).name, 'pattern');
+			assert.strictEqual((actual as Entry).path, 'pattern');
 		});
 
 		it('should return null when lstat throw error', () => {

--- a/src/adapters/fs.spec.ts
+++ b/src/adapters/fs.spec.ts
@@ -1,8 +1,9 @@
 import * as assert from 'assert';
 import * as path from 'path';
 
+import { Stats } from '@nodelib/fs.macchiato';
+
 import Settings from '../settings';
-import * as tests from '../tests/index';
 import FileSystem from './fs';
 
 class FileSystemFake extends FileSystem<never[]> {
@@ -53,18 +54,10 @@ describe('Adapters → FileSystem', () => {
 			const adapter = getAdapter();
 
 			const filepath = path.join('base', 'file.json');
-			const actual = adapter.makeEntry(tests.getFileEntry(), filepath);
+			const actual = adapter.makeEntry(new Stats(), filepath);
 
 			assert.strictEqual(actual.path, filepath);
-			assert.strictEqual(actual.depth, 2);
-		});
-
-		it('issue-144: should return entry with methods from fs.Stats', () => {
-			const adapter = getAdapter();
-
-			const actual = adapter.makeEntry(tests.getFileEntry(), 'file.json');
-
-			assert.ok(actual.isFile());
+			assert.ok(actual.dirent.isFile());
 		});
 	});
 });

--- a/src/adapters/fs.ts
+++ b/src/adapters/fs.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 import Settings from '../settings';
 import { Entry, EntryFilterFunction, Pattern } from '../types/index';
+import * as utils from '../utils/index';
 
 export default abstract class FileSystem<T> {
 	constructor(private readonly _settings: Settings) { }
@@ -22,10 +23,17 @@ export default abstract class FileSystem<T> {
 	/**
 	 * Return an implementation of the Entry interface.
 	 */
-	public makeEntry(stat: fs.Stats, pattern: Pattern): Entry {
-		(stat as Entry).path = pattern;
-		(stat as Entry).depth = pattern.split(path.sep).length;
+	public makeEntry(stats: fs.Stats, pattern: Pattern): Entry {
+		const entry: Entry = {
+			name: pattern,
+			path: pattern,
+			dirent: utils.fs.createDirentFromStats(pattern, stats)
+		};
 
-		return stat as Entry;
+		if (this._settings.stats) {
+			entry.stats = stats;
+		}
+
+		return entry;
 	}
 }

--- a/src/providers/async.spec.ts
+++ b/src/providers/async.spec.ts
@@ -24,10 +24,10 @@ class TestReaderStream extends ReaderStream {
 }
 
 class TestProviderAsync extends ProviderAsync {
-	protected readonly _reader: TestReaderStream = new TestReaderStream(this.settings);
+	protected readonly _reader: TestReaderStream = new TestReaderStream(this._settings);
 
-	constructor(public settings: Settings = new Settings()) {
-		super(settings);
+	constructor(protected _settings: Settings = new Settings()) {
+		super(_settings);
 	}
 }
 

--- a/src/providers/async.ts
+++ b/src/providers/async.ts
@@ -23,7 +23,7 @@ export default class ProviderAsync extends Provider<Promise<EntryItem[]>> {
 				stream.pause();
 			});
 
-			stream.on('data', (entry: Entry) => entries.push(this.transform(entry)));
+			stream.on('data', (entry: Entry) => entries.push(options.transform(entry)));
 			stream.on('end', () => resolve(entries));
 		});
 	}

--- a/src/providers/async.ts
+++ b/src/providers/async.ts
@@ -4,7 +4,7 @@ import { Entry, EntryItem, ReaderOptions } from '../types/index';
 import Provider from './provider';
 
 export default class ProviderAsync extends Provider<Promise<EntryItem[]>> {
-	protected _reader: ReaderStream = new ReaderStream(this.settings);
+	protected _reader: ReaderStream = new ReaderStream(this._settings);
 
 	/**
 	 * Use async API to read entries for Task.

--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -15,7 +15,7 @@ function getDeepFilterInstance(options?: Options): DeepFilter {
 }
 
 function getFilter(positive: Pattern[], negative: Pattern[], options?: Options): EntryFilterFunction {
-	return getDeepFilterInstance(options).getFilter(positive, negative);
+	return getDeepFilterInstance(options).getFilter('base', positive, negative);
 }
 
 describe('Providers → Filters → Deep', () => {

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -62,14 +62,14 @@ export default class EntryFilter {
 	 * Returns true for non-files if the «onlyFiles» option is enabled.
 	 */
 	private _onlyFileFilter(entry: Entry): boolean {
-		return this._settings.onlyFiles && !entry.isFile();
+		return this._settings.onlyFiles && !entry.dirent.isFile();
 	}
 
 	/**
 	 * Returns true for non-directories if the «onlyDirectories» option is enabled.
 	 */
 	private _onlyDirectoryFilter(entry: Entry): boolean {
-		return this._settings.onlyDirectories && !entry.isDirectory();
+		return this._settings.onlyDirectories && !entry.dirent.isDirectory();
 	}
 
 	/**

--- a/src/providers/provider.spec.ts
+++ b/src/providers/provider.spec.ts
@@ -63,8 +63,9 @@ describe('Providers → Provider', () => {
 			});
 
 			assert.strictEqual(actual.basePath, '');
-			assert.strictEqual(typeof actual.filter, 'function');
-			assert.strictEqual(typeof actual.deep, 'function');
+			assert.strictEqual(typeof actual.entryFilter, 'function');
+			assert.strictEqual(typeof actual.deepFilter, 'function');
+			assert.strictEqual(typeof actual.transform, 'function');
 		});
 
 		it('should return options for reader with non-global base (fixtures)', () => {
@@ -79,8 +80,9 @@ describe('Providers → Provider', () => {
 			});
 
 			assert.strictEqual(actual.basePath, 'fixtures');
-			assert.strictEqual(typeof actual.filter, 'function');
-			assert.strictEqual(typeof actual.deep, 'function');
+			assert.strictEqual(typeof actual.entryFilter, 'function');
+			assert.strictEqual(typeof actual.deepFilter, 'function');
+			assert.strictEqual(typeof actual.transform, 'function');
 		});
 	});
 

--- a/src/providers/provider.spec.ts
+++ b/src/providers/provider.spec.ts
@@ -5,7 +5,6 @@ import { Task } from '../managers/tasks';
 import Settings, { Options } from '../settings';
 import * as tests from '../tests';
 import { MicromatchOptions } from '../types/index';
-import * as utils from '../utils/index';
 import Provider from './provider';
 
 export class TestProvider extends Provider<Array<{}>> {
@@ -101,118 +100,6 @@ describe('Providers → Provider', () => {
 			const actual = provider.getMicromatchOptions();
 
 			assert.deepStrictEqual(actual, expected);
-		});
-	});
-
-	describe('.transform', () => {
-		describe('The «markDirectories» option', () => {
-			it('should return mark directory when option is enabled', () => {
-				const provider = getProvider({ markDirectories: true });
-				const entry = tests.getDirectoryEntry();
-
-				const expected = 'fixtures/directory/';
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
-
-			it('should return mark directory when option is enabled with the absolute option enabled', () => {
-				const provider = getProvider({ markDirectories: true, absolute: true });
-				const entry = tests.getDirectoryEntry();
-
-				const fullpath = path.join(process.cwd(), 'fixtures/directory/');
-				const expected = utils.path.unixify(fullpath);
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
-
-			it('should do nothing with file when option is enabled', () => {
-				const provider = getProvider({ markDirectories: true });
-				const entry = tests.getFileEntry();
-
-				const expected = 'fixtures/file.txt';
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
-
-			it('should return non-marked directory when option is disabled', () => {
-				const provider = getProvider();
-				const entry = tests.getDirectoryEntry();
-
-				const expected = 'fixtures/directory';
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
-		});
-
-		describe('The «absolute» option', () => {
-			it('should return transformed entry when option is provided', () => {
-				const provider = getProvider({ absolute: true });
-				const entry = tests.getFileEntry();
-
-				const fullpath = path.join(process.cwd(), 'fixtures', 'file.txt');
-				const expected = utils.path.unixify(fullpath);
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
-
-			it('should transform event absolute filepath when option is provided', () => {
-				const provider = getProvider({ absolute: true });
-				const entry = tests.getFileEntry({
-					path: `${process.cwd()}/fixtures/../file.txt`
-				});
-
-				const fullpath = path.join(process.cwd(), 'file.txt');
-				const expected = utils.path.unixify(fullpath);
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
-
-			it('should return do nothing when option is not provided', () => {
-				const provider = getProvider();
-				const entry = tests.getFileEntry();
-
-				const expected = 'fixtures/file.txt';
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
-		});
-
-		describe('The «transform» option', () => {
-			it('should return transformed entry when option is provided', () => {
-				const provider = getProvider({ transform: () => 'cake' });
-				const entry = tests.getDirectoryEntry();
-
-				const expected = 'cake';
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
-
-			it('should return do nothing when option is not provided', () => {
-				const provider = getProvider();
-				const entry = tests.getDirectoryEntry();
-
-				const expected = 'fixtures/directory';
-
-				const actual = provider.transform(entry);
-
-				assert.strictEqual(actual, expected);
-			});
 		});
 	});
 

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -38,10 +38,12 @@ export default abstract class Provider<T> {
 	 * Returns options for reader.
 	 */
 	public getReaderOptions(task: Task): ReaderOptions {
+		const basePath = task.base === '.' ? '' : task.base;
+
 		return {
-			basePath: task.base === '.' ? '' : task.base,
-			filter: this.entryFilter.getFilter(task.positive, task.negative),
-			deep: this.deepFilter.getFilter(task.positive, task.negative),
+			basePath,
+			entryFilter: this.entryFilter.getFilter(task.positive, task.negative),
+			deepFilter: this.deepFilter.getFilter(basePath, task.positive, task.negative),
 			transform: this.entryTransformer.getTransformer()
 		};
 	}

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -14,12 +14,12 @@ export default abstract class Provider<T> {
 
 	private readonly _micromatchOptions: MicromatchOptions;
 
-	constructor(public readonly settings: Settings) {
+	constructor(protected readonly _settings: Settings) {
 		this._micromatchOptions = this.getMicromatchOptions();
 
-		this.entryFilter = new EntryFilter(settings, this._micromatchOptions);
-		this.deepFilter = new DeepFilter(settings, this._micromatchOptions);
-		this.entryTransformer = new EntryTransformer(settings);
+		this.entryFilter = new EntryFilter(_settings, this._micromatchOptions);
+		this.deepFilter = new DeepFilter(_settings, this._micromatchOptions);
+		this.entryTransformer = new EntryTransformer(_settings);
 	}
 
 	/**
@@ -31,7 +31,7 @@ export default abstract class Provider<T> {
 	 * Returns root path to scanner.
 	 */
 	public getRootDirectory(task: Task): string {
-		return path.resolve(this.settings.cwd, task.base);
+		return path.resolve(this._settings.cwd, task.base);
 	}
 
 	/**
@@ -51,12 +51,12 @@ export default abstract class Provider<T> {
 	 */
 	public getMicromatchOptions(): MicromatchOptions {
 		return {
-			dot: this.settings.dot,
-			nobrace: !this.settings.brace,
-			noglobstar: !this.settings.globstar,
-			noext: !this.settings.extglob,
-			nocase: !this.settings.case,
-			matchBase: this.settings.matchBase
+			dot: this._settings.dot,
+			nobrace: !this._settings.brace,
+			noglobstar: !this._settings.globstar,
+			noext: !this._settings.extglob,
+			nocase: !this._settings.case,
+			matchBase: this._settings.matchBase
 		};
 	}
 

--- a/src/providers/stream.spec.ts
+++ b/src/providers/stream.spec.ts
@@ -24,10 +24,10 @@ class TestReaderStream extends ReaderStream {
 }
 
 class TestProviderStream extends ProviderStream {
-	protected readonly _reader: TestReaderStream = new TestReaderStream(this.settings);
+	protected readonly _reader: TestReaderStream = new TestReaderStream(this._settings);
 
-	constructor(public settings: Settings = new Settings()) {
-		super(settings);
+	constructor(protected _settings: Settings = new Settings()) {
+		super(_settings);
 	}
 }
 

--- a/src/providers/stream.ts
+++ b/src/providers/stream.ts
@@ -7,12 +7,12 @@ import { Entry, ReaderOptions } from '../types/index';
 import Provider from './provider';
 
 class TransformStream extends stream.Transform {
-	constructor(private readonly _provider: ProviderStream) {
+	constructor(private readonly _options: ReaderOptions) {
 		super({ objectMode: true });
 	}
 
 	public _transform(entry: Entry, _encoding: string, callback: Function): void {
-		callback(null, this._provider.transform(entry));
+		callback(null, this._options.transform(entry));
 	}
 }
 
@@ -32,7 +32,7 @@ export default class ProviderStream extends Provider<NodeJS.ReadableStream> {
 	public read(task: Task): NodeJS.ReadableStream {
 		const root = this.getRootDirectory(task);
 		const options = this.getReaderOptions(task);
-		const transform = new TransformStream(this);
+		const transform = new TransformStream(options);
 
 		const readable: NodeJS.ReadableStream = this.api(root, task, options);
 

--- a/src/providers/stream.ts
+++ b/src/providers/stream.ts
@@ -17,13 +17,13 @@ class TransformStream extends stream.Transform {
 }
 
 export default class ProviderStream extends Provider<NodeJS.ReadableStream> {
-	protected _reader: ReaderStream = new ReaderStream(this.settings);
+	protected _reader: ReaderStream = new ReaderStream(this._settings);
 
 	/**
 	 * Returns FileSystem adapter.
 	 */
 	public get fsAdapter(): FileSystemStream {
-		return new FileSystemStream(this.settings);
+		return new FileSystemStream(this._settings);
 	}
 
 	/**

--- a/src/providers/sync.spec.ts
+++ b/src/providers/sync.spec.ts
@@ -20,10 +20,10 @@ class TestReaderSync extends ReaderSync {
 }
 
 class TestProviderSync extends ProviderSync {
-	protected readonly _reader: ReaderSync = new TestReaderSync(this.settings);
+	protected readonly _reader: ReaderSync = new TestReaderSync(this._settings);
 
-	constructor(public settings: Settings = new Settings()) {
-		super(settings);
+	constructor(protected _settings: Settings = new Settings()) {
+		super(_settings);
 	}
 }
 

--- a/src/providers/sync.ts
+++ b/src/providers/sync.ts
@@ -16,7 +16,7 @@ export default class ProviderSync extends Provider<EntryItem[]> {
 		try {
 			const entries: Entry[] = this.api(root, task, options);
 
-			return entries.map<EntryItem>(this.transform, this);
+			return entries.map<EntryItem>(options.transform);
 		} catch (err) {
 			if (this.isEnoentCodeError(err as NodeJS.ErrnoException)) {
 				return [];

--- a/src/providers/sync.ts
+++ b/src/providers/sync.ts
@@ -4,7 +4,7 @@ import { Entry, EntryItem, ReaderOptions } from '../types/index';
 import Provider from './provider';
 
 export default class ProviderSync extends Provider<EntryItem[]> {
-	protected _reader: ReaderSync = new ReaderSync(this.settings);
+	protected _reader: ReaderSync = new ReaderSync(this._settings);
 
 	/**
 	 * Use sync API to read entries for Task.

--- a/src/providers/transformers/entry.spec.ts
+++ b/src/providers/transformers/entry.spec.ts
@@ -1,0 +1,96 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+import Settings, { Options } from '../../settings';
+import * as tests from '../../tests/index';
+import { EntryTransformerFunction } from '../../types';
+import * as utils from '../../utils/index';
+import EntryTransformer from './entry';
+
+function getEntryTransformerInstance(options?: Options): EntryTransformer {
+	return new EntryTransformer(new Settings(options));
+}
+
+function getTransformer(options?: Options): EntryTransformerFunction {
+	return getEntryTransformerInstance(options).getTransformer();
+}
+
+describe('Providers → Transformers → Entry', () => {
+	describe('Constructor', () => {
+		it('should create instance of class', () => {
+			const filter = getEntryTransformerInstance();
+
+			assert.ok(filter instanceof EntryTransformer);
+		});
+	});
+
+	describe('.getFilter', () => {
+		it('should return transformed entry as string when options is not provided', () => {
+			const transformer = getTransformer();
+			const entry = tests.getFileEntry();
+
+			const expected = 'fixtures/file.txt';
+
+			const actual = transformer(entry);
+
+			assert.strictEqual(actual, expected);
+		});
+
+		it('should return transformed entry as object when the `stats` option is enabled', () => {
+			const transformer = getTransformer({ stats: true });
+			const entry = tests.getFileEntry();
+
+			const expected = entry;
+
+			const actual = transformer(entry);
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should apply custom transform function', () => {
+			const transformer = getTransformer({ transform: () => 'cake' });
+			const entry = tests.getFileEntry();
+
+			const expected = 'cake';
+
+			const actual = transformer(entry);
+
+			assert.strictEqual(actual, expected);
+		});
+
+		it('should return entry with absolute filepath when the `absolute` option is enabled', () => {
+			const transformer = getTransformer({ absolute: true });
+			const entry = tests.getFileEntry();
+
+			const fullpath = path.join(process.cwd(), 'fixtures', 'file.txt');
+			const expected = utils.path.unixify(fullpath);
+
+			const actual = transformer(entry);
+
+			assert.strictEqual(actual, expected);
+		});
+
+		it('should return entry with trailing slash when the `markDirectories` is enabled', () => {
+			const transformer = getTransformer({ markDirectories: true });
+			const entry = tests.getDirectoryEntry();
+
+			const expected = 'fixtures/directory/';
+
+			const actual = transformer(entry);
+
+			assert.strictEqual(actual, expected);
+		});
+
+		it('should return correct entry when the `absolute` and `markDirectories` options is enabled', () => {
+			const transformer = getTransformer({ absolute: true, markDirectories: true });
+			const entry = tests.getDirectoryEntry();
+
+			const fullpath = path.join(process.cwd(), 'fixtures', 'directory', '/');
+			const expected = utils.path.unixify(fullpath);
+
+			const actual = transformer(entry);
+
+			assert.strictEqual(actual, expected);
+		});
+	});
+});

--- a/src/providers/transformers/entry.ts
+++ b/src/providers/transformers/entry.ts
@@ -16,7 +16,7 @@ export default class EntryTransformer {
 			entry.path = utils.path.makeAbsolute(this._settings.cwd, entry.path);
 		}
 
-		if (this._settings.markDirectories && entry.isDirectory()) {
+		if (this._settings.markDirectories && entry.dirent.isDirectory()) {
 			entry.path = path.join(entry.path, path.sep);
 		}
 

--- a/src/providers/transformers/entry.ts
+++ b/src/providers/transformers/entry.ts
@@ -1,0 +1,33 @@
+import * as path from 'path';
+
+import Settings from '../../settings';
+import { Entry, EntryItem, EntryTransformerFunction } from '../../types';
+import * as utils from '../../utils/index';
+
+export default class EntryTransformer {
+	constructor(private readonly _settings: Settings) { }
+
+	public getTransformer(): EntryTransformerFunction {
+		return (entry: Entry) => this._transform(entry);
+	}
+
+	private _transform(entry: Entry): EntryItem {
+		if (this._settings.absolute) {
+			entry.path = utils.path.makeAbsolute(this._settings.cwd, entry.path);
+		}
+
+		if (this._settings.markDirectories && entry.isDirectory()) {
+			entry.path = path.join(entry.path, path.sep);
+		}
+
+		entry.path = utils.path.unixify(entry.path);
+
+		const item: EntryItem = this._settings.stats ? entry : entry.path;
+
+		if (this._settings.transform === null) {
+			return item;
+		}
+
+		return this._settings.transform(item);
+	}
+}

--- a/src/readers/stream.ts
+++ b/src/readers/stream.ts
@@ -1,17 +1,17 @@
-import * as readdir from '@mrmlnc/readdir-enhanced';
+import * as fsWalk from '@nodelib/fs.walk';
 
 import FileSystemStream from '../adapters/fs-stream';
-import { EntryFilterFunction, ReaderOptions } from '../types/index';
+import { ReaderOptions } from '../types/index';
 import Reader from './reader';
 
 export default class ReaderStream extends Reader<NodeJS.ReadableStream> {
 	private readonly _fsAdapter: FileSystemStream = new FileSystemStream(this._settings);
 
 	public dynamic(root: string, options: ReaderOptions): NodeJS.ReadableStream {
-		return readdir.readdirStreamStat(root, options);
+		return fsWalk.walkStream(root, options);
 	}
 
 	public static(filepaths: string[], options: ReaderOptions): NodeJS.ReadableStream {
-		return this._fsAdapter.read(filepaths, options.filter as EntryFilterFunction);
+		return this._fsAdapter.read(filepaths, options.entryFilter);
 	}
 }

--- a/src/readers/sync.ts
+++ b/src/readers/sync.ts
@@ -1,17 +1,17 @@
-import * as readdir from '@mrmlnc/readdir-enhanced';
+import * as fsWalk from '@nodelib/fs.walk';
 
 import FileSystemSync from '../adapters/fs-sync';
-import { Entry, EntryFilterFunction, ReaderOptions } from '../types/index';
+import { Entry, ReaderOptions } from '../types/index';
 import Reader from './reader';
 
 export default class ReaderSync extends Reader<Entry[]> {
 	private readonly _fsAdapter: FileSystemSync = new FileSystemSync(this._settings);
 
 	public dynamic(root: string, options: ReaderOptions): Entry[] {
-		return readdir.readdirSyncStat(root, options);
+		return fsWalk.walkSync(root, options);
 	}
 
 	public static(filepaths: string[], options: ReaderOptions): Entry[] {
-		return this._fsAdapter.read(filepaths, options.filter as EntryFilterFunction);
+		return this._fsAdapter.read(filepaths, options.entryFilter);
 	}
 }

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,6 +1,7 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import * as stream from 'stream';
+
+import { Dirent } from '@nodelib/fs.macchiato';
 
 import { Entry, EntryItem } from '../types/index';
 
@@ -28,48 +29,40 @@ export class EnoentErrnoException extends Error {
 }
 
 interface FakeFsStatOptions {
-	isFile: boolean;
-	isDirectory: boolean;
-	isSymbolicLink: boolean;
-	path: string;
+	name?: string;
+	isFile?: boolean;
+	isDirectory?: boolean;
+	isSymbolicLink?: boolean;
+	path?: string;
 }
 
-class FakeEntry extends fs.Stats {
-	public path: string = this._options.path || path.join('fixtures', 'entry');
-	public depth: number = this.path.split(path.sep).length - 2;
+class FakeEntry implements Entry {
+	public readonly name: string = this._options.name || 'file.txt';
+	public readonly path: string = this._options.path || path.join('fixtures', 'file.txt');
+	public readonly dirent: Dirent = new Dirent({
+		...this._options,
+		name: this.name
+	});
 
-	constructor(private readonly _options: Partial<FakeFsStatOptions> = {}) {
-		super();
-	}
-
-	public isFile(): boolean {
-		return this._options.isFile || false;
-	}
-
-	public isDirectory(): boolean {
-		return this._options.isDirectory || false;
-	}
-
-	public isSymbolicLink(): boolean {
-		return this._options.isSymbolicLink || false;
-	}
+	constructor(private readonly _options: FakeFsStatOptions = {}) { }
 }
 
-export function getEntry(options: Partial<FakeFsStatOptions> = {}): Entry {
+export function getEntry(options: FakeFsStatOptions = {}): Entry {
 	return new FakeEntry(options);
 }
 
-export function getFileEntry(options: Partial<FakeFsStatOptions> = {}): Entry {
+export function getFileEntry(options: FakeFsStatOptions = {}): Entry {
 	return new FakeEntry({
 		isFile: true,
-		path: path.join('fixtures', 'file.txt'),
 		...options
 	});
 }
 
 export function getDirectoryEntry(options: Partial<FakeFsStatOptions> = {}): Entry {
 	return new FakeEntry({
+		isFile: false,
 		isDirectory: true,
+		name: 'directory',
 		path: path.join('fixtures', 'directory'),
 		...options
 	});

--- a/src/tests/smoke/static.smoke.ts
+++ b/src/tests/smoke/static.smoke.ts
@@ -73,7 +73,7 @@ smoke.suite('Smoke → Static (stats)', [
 		fgOptions: {
 			stats: true,
 			transform: (entry) => {
-				assert.ok((entry as Entry).isFile());
+				assert.ok((entry as Entry).dirent.isFile());
 
 				return (entry as Entry).path;
 			}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,10 @@ export type Pattern = string;
 export type PatternRe = RegExp;
 export type PatternsGroup = Record<string, Pattern[]>;
 
-export type ReaderOptions = readdir.Options;
+export interface ReaderOptions extends readdir.Options {
+	transform(entry: Entry): EntryItem;
+}
+
 export type EntryFilterFunction = readdir.FilterFunction;
+export type EntryTransformerFunction = (entry: Entry) => EntryItem;
 export type MicromatchOptions = micromatch.Options;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,24 +1,22 @@
-import * as fs from 'fs';
+import * as fsWalk from '@nodelib/fs.walk';
 
-import * as readdir from '@mrmlnc/readdir-enhanced';
 import * as micromatch from 'micromatch';
 
-// Must be synchronized with readdir-enhanced
-export interface Entry extends fs.Stats {
-	path: string;
-	depth: number;
-}
-
+export type Entry = fsWalk.Entry;
 export type EntryItem = string | Entry;
 
 export type Pattern = string;
 export type PatternRe = RegExp;
 export type PatternsGroup = Record<string, Pattern[]>;
 
-export interface ReaderOptions extends readdir.Options {
+export interface ReaderOptions {
+	basePath: string | null;
+	entryFilter: EntryFilterFunction;
+	deepFilter: DeepFilterFunction;
 	transform(entry: Entry): EntryItem;
 }
 
-export type EntryFilterFunction = readdir.FilterFunction;
+export type EntryFilterFunction = fsWalk.EntryFilterFunction;
+export type DeepFilterFunction = fsWalk.DeepFilterFunction;
 export type EntryTransformerFunction = (entry: Entry) => EntryItem;
 export type MicromatchOptions = micromatch.Options;

--- a/src/utils/fs.spec.ts
+++ b/src/utils/fs.spec.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert';
+
+import { Stats } from '@nodelib/fs.macchiato';
+import * as util from './fs';
+
+describe('Utils → FS', () => {
+	describe('.createDirentFromStats', () => {
+		it('should convert fs.Stats to fs.Dirent', () => {
+			const actual = util.createDirentFromStats('name', new Stats());
+
+			assert.strictEqual(actual.name, 'name');
+			assert.ok(!actual.isBlockDevice());
+			assert.ok(!actual.isCharacterDevice());
+			assert.ok(!actual.isDirectory());
+			assert.ok(!actual.isFIFO());
+			assert.ok(actual.isFile());
+			assert.ok(!actual.isSocket());
+			assert.ok(!actual.isSymbolicLink());
+		});
+	});
+});

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+
+import { Dirent } from '@nodelib/fs.walk';
+
+class DirentFromStats implements fs.Dirent {
+	public isBlockDevice: fs.Stats['isBlockDevice'];
+	public isCharacterDevice: fs.Stats['isCharacterDevice'];
+	public isDirectory: fs.Stats['isDirectory'];
+	public isFIFO: fs.Stats['isFIFO'];
+	public isFile: fs.Stats['isFile'];
+	public isSocket: fs.Stats['isSocket'];
+	public isSymbolicLink: fs.Stats['isSymbolicLink'];
+
+	constructor(public name: string, stats: fs.Stats) {
+		this.isBlockDevice = stats.isBlockDevice.bind(stats);
+		this.isCharacterDevice = stats.isCharacterDevice.bind(stats);
+		this.isDirectory = stats.isDirectory.bind(stats);
+		this.isFIFO = stats.isFIFO.bind(stats);
+		this.isFile = stats.isFile.bind(stats);
+		this.isSocket = stats.isSocket.bind(stats);
+		this.isSymbolicLink = stats.isSymbolicLink.bind(stats);
+	}
+}
+
+export function createDirentFromStats(name: string, stats: fs.Stats): Dirent {
+	return new DirentFromStats(name, stats);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,12 @@
 import * as array from './array';
+import * as fs from './fs';
 import * as path from './path';
 import * as pattern from './pattern';
 import * as stream from './stream';
 
 export {
 	array,
+	fs,
 	path,
 	pattern,
 	stream


### PR DESCRIPTION
### What is the purpose of this pull request?

Close issues:  #163, #161, #147

### What changes did you make? (Give an overview)

* Use `@nodelib/fs.walk` instead of `@mrmlnc/readdir-enhanced` for crawl file system.
