### PR TITLE
ISSUE-147: fix stream performance

### DIFF
--- a/src/utils/stream.spec.ts
+++ b/src/utils/stream.spec.ts
@@ -5,6 +5,14 @@ import * as util from './stream';
 
 describe('Utils → Stream', () => {
 	describe('.merge', () => {
+		it('should return source stream as is, when he is alone', () => {
+			const source = new stream.PassThrough();
+
+			const actual = util.merge([source]);
+
+			assert.strictEqual(actual, source);
+		});
+
 		it('should merge two streams into one stream', () => {
 			const first = new stream.PassThrough();
 			const second = new stream.PassThrough();

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -4,6 +4,14 @@ import merge2 = require('merge2');
  * Merge multiple streams and propagate their errors into one stream in parallel.
  */
 export function merge(streams: NodeJS.ReadableStream[]): NodeJS.ReadableStream {
+	/**
+	 * Multiplexing leads to the creation of a new stream.
+	 * If the source is one, then there is nothing to multiplex.
+	 */
+	if (streams.length === 1) {
+		return streams[0];
+	}
+
 	const mergedStream = merge2(streams);
 
 	streams.forEach((stream) => {


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for issue #147.

### What changes did you make? (Give an overview)

Multiplexing leads to the creation of a new stream. If the source is one, then there is nothing to multiplex and we do not create additional stream by performance reasons.

**before**

```
(TIME) 359.030ms ±7.080% | (MEMORY) 6.691MB ±0.062% | Entries: 5211 | Errors: 0 | Retries: 1
```

**after**

```
(TIME) 245.260ms ±3.078% | (MEMORY) 5.811MB ±0.037% | Entries: 5211 | Errors: 0 | Retries: 1
```