### PR TITLE
fix(deps): @types/micromatch should be a prod dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@types/glob-parent": "^3.1.1",
     "@types/is-glob": "^4.0.1",
     "@types/merge2": "^1.1.4",
-    "@types/micromatch": "^3.1.0",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^11.13.6",
@@ -51,6 +50,7 @@
   "dependencies": {
     "@nodelib/fs.stat": "^2.0.0",
     "@nodelib/fs.walk": "^1.1.0",
+    "@types/micromatch": "^3.1.0",
     "glob-parent": "^5.0.0",
     "is-glob": "^4.0.0",
     "merge2": "^1.2.3",


### PR DESCRIPTION
### What is the purpose of this pull request?

to fix the pnpm build: https://github.com/pnpm/pnpm/pull/1875

### What changes did you make? (Give an overview)

making a type dep a prod dep
