### PR TITLE
Fix onlyFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ fg.sync('*', { onlyDirectories: true });  // ['src']
 #### onlyFiles
 
 * Type: `boolean`
-* Default: `false`
+* Default: `true`
 
 Return only files.
 


### PR DESCRIPTION
Seems like it hasn't changed from before (should be `true`), after testing it. So I corrected it in the readme.