### PR TITLE
PICOMATCH-21: Disable strictSlashes option by default

### DIFF
--- a/src/providers/provider.spec.ts
+++ b/src/providers/provider.spec.ts
@@ -105,7 +105,8 @@ describe('Providers → Provider', () => {
 				nocase: false,
 				noext: false,
 				noglobstar: false,
-				posix: true
+				posix: true,
+				strictSlashes: false
 			};
 
 			const actual = provider.getMicromatchOptions();

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -48,7 +48,8 @@ export default abstract class Provider<T> {
 			nocase: !this._settings.caseSensitiveMatch,
 			noext: !this._settings.extglob,
 			noglobstar: !this._settings.globstar,
-			posix: true
+			posix: true,
+			strictSlashes: false
 		};
 	}
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export interface MicromatchOptions {
 	noext?: boolean;
 	noglobstar?: boolean;
 	posix?: boolean;
+	strictSlashes?: boolean;
 }
 
 export type FileSystemAdapter = fsWalk.FileSystemAdapter;


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a preparing for a new version of the picomatch/micromatch package where the `strictSlashes` will be enabled by default.

https://github.com/micromatch/picomatch/issues/21

### What changes did you make? (Give an overview)

* Set the `strictSlashes` option to `false`.