### PR TITLE
Add base path of entry for objectMode

### DIFF
--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -9,7 +9,7 @@ export default class DeepFilter {
 		const maxPatternDepth = this._getMaxPatternDepth(positive);
 		const negativeRe = this._getNegativePatternsRe(negative);
 
-		return (entry) => this._filter(basePath, entry, negativeRe, maxPatternDepth);
+		return (entry) => this._filter(basePath, entry as Entry, negativeRe, maxPatternDepth);
 	}
 
 	private _getMaxPatternDepth(patterns: Pattern[]): number {

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -11,7 +11,7 @@ export default class EntryFilter {
 		const positiveRe = utils.pattern.convertPatternsToRe(positive, this._micromatchOptions);
 		const negativeRe = utils.pattern.convertPatternsToRe(negative, this._micromatchOptions);
 
-		return (entry) => this._filter(entry, positiveRe, negativeRe);
+		return (entry) => this._filter(entry as Entry, positiveRe, negativeRe);
 	}
 
 	private _filter(entry: Entry, positiveRe: PatternRe[], negativeRe: PatternRe[]): boolean {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -36,7 +36,7 @@ export default abstract class Provider<T> {
 			fs: this._settings.fs,
 			stats: this._settings.stats,
 			throwErrorOnBrokenSymbolicLink: this._settings.throwErrorOnBrokenSymbolicLink,
-			transform: this.entryTransformer.getTransformer()
+			transform: this.entryTransformer.getTransformer(basePath)
 		};
 	}
 

--- a/src/providers/transformers/entry.spec.ts
+++ b/src/providers/transformers/entry.spec.ts
@@ -12,7 +12,7 @@ function getEntryTransformer(options?: Options): EntryTransformer {
 }
 
 function getTransformer(options?: Options): EntryTransformerFunction {
-	return getEntryTransformer(options).getTransformer();
+	return getEntryTransformer(options).getTransformer('');
 }
 
 describe('Providers → Transformers → Entry', () => {

--- a/src/providers/transformers/entry.ts
+++ b/src/providers/transformers/entry.ts
@@ -5,11 +5,11 @@ import * as utils from '../../utils/index';
 export default class EntryTransformer {
 	constructor(private readonly _settings: Settings) { }
 
-	public getTransformer(): EntryTransformerFunction {
-		return (entry) => this._transform(entry);
+	public getTransformer(basePath: string): EntryTransformerFunction {
+		return (entry) => this._transform(basePath, entry);
 	}
 
-	private _transform(entry: Entry): EntryItem {
+	private _transform(basePath: string, entry: Entry): EntryItem {
 		let filepath = entry.path;
 
 		if (this._settings.absolute) {
@@ -27,6 +27,7 @@ export default class EntryTransformer {
 
 		return {
 			...entry,
+			base: basePath,
 			path: filepath
 		};
 	}

--- a/src/readers/reader.ts
+++ b/src/readers/reader.ts
@@ -25,6 +25,7 @@ export default abstract class Reader<T> {
 
 	protected _makeEntry(stats: fs.Stats, pattern: Pattern): Entry {
 		const entry: Entry = {
+			base: pattern,
 			name: pattern,
 			path: pattern,
 			dirent: utils.fs.createDirentFromStats(pattern, stats)

--- a/src/readers/sync.ts
+++ b/src/readers/sync.ts
@@ -11,7 +11,7 @@ export default class ReaderSync extends Reader<Entry[]> {
 	protected _statSync: typeof fsStat.statSync = fsStat.statSync;
 
 	public dynamic(root: string, options: ReaderOptions): Entry[] {
-		return this._walkSync(root, options);
+		return this._walkSync(root, options) as Entry[];
 	}
 
 	public static(patterns: Pattern[], options: ReaderOptions): Entry[] {

--- a/src/tests/utils/entry.ts
+++ b/src/tests/utils/entry.ts
@@ -10,6 +10,7 @@ class EntryBuilder {
 	private _isSymbolicLink: boolean = false;
 
 	private readonly _entry: Entry = {
+		base: '',
 		name: '',
 		path: '',
 		dirent: new Dirent()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,9 @@ import * as fsWalk from '@nodelib/fs.walk';
 
 export type ErrnoException = NodeJS.ErrnoException;
 
-export type Entry = fsWalk.Entry;
+export interface Entry extends fsWalk.Entry {
+	base: string;
+}
 export type EntryItem = string | Entry;
 
 export type Pattern = string;


### PR DESCRIPTION
### What is the purpose of this pull request?

For `objectMode` the base path of entry should be return, otherwise we can't get the base path through the results.

### What changes did you make? (Give an overview)

- add `base` property for `Entry`
- add `basePath` param for `EntryTransformer.getTransformer(basePath: string)`
