### PR TITLE
ISSUE-226: match dot directories by patterns

### DIFF
--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -87,17 +87,6 @@ describe('Providers → Filters → Deep', () => {
 			});
 		});
 
-		describe('options.dot', () => {
-			it('should return `false` when an entry basename starts with dot and option is disabled', () => {
-				const filter = getFilter('.', ['**/*'], [], { dot: false });
-				const entry = tests.entry.builder().path('root/.directory').directory().build();
-
-				const actual = filter(entry);
-
-				assert.ok(!actual);
-			});
-		});
-
 		describe('Pattern', () => {
 			it('should return `false` when an entry match to the negative pattern', () => {
 				const filter = getFilter('.', ['**/*'], ['root/**']);
@@ -108,7 +97,7 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(!actual);
 			});
 
-			it('should return `treu` when the positive pattern has no affect to depth reading, but the `baseNameMatch` is enabled', () => {
+			it('should return `true` when the positive pattern has no affect to depth reading, but the `baseNameMatch` is enabled', () => {
 				const filter = getFilter('.', ['*'], [], { baseNameMatch: true });
 				const entry = tests.entry.builder().path('root/directory').directory().build();
 

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -39,10 +39,6 @@ export default class DeepFilter {
 			return false;
 		}
 
-		if (this._isSkippedDotDirectory(entry)) {
-			return false;
-		}
-
 		return this._isSkippedByNegativePatterns(entry, negativeRe);
 	}
 
@@ -63,10 +59,6 @@ export default class DeepFilter {
 
 	private _isSkippedSymbolicLink(entry: Entry): boolean {
 		return !this._settings.followSymbolicLinks && entry.dirent.isSymbolicLink();
-	}
-
-	private _isSkippedDotDirectory(entry: Entry): boolean {
-		return !this._settings.dot && entry.name.startsWith('.');
 	}
 
 	private _isSkippedByNegativePatterns(entry: Entry, negativeRe: PatternRe[]): boolean {

--- a/src/tests/smoke/dot.smoke.ts
+++ b/src/tests/smoke/dot.smoke.ts
@@ -17,5 +17,19 @@ smoke.suite('Smoke → Dot', [
 		pattern: 'fixtures/**/*',
 		globOptions: { dot: true },
 		fgOptions: { dot: true }
+	},
+
+	{ pattern: 'fixtures/{.,}*' },
+	{ pattern: 'fixtures/{.*,*}' },
+	{ pattern: 'fixtures/**/{.,}*' },
+	{
+		pattern: 'fixtures/{.**,**}',
+		broken: true,
+		issue: 47
+	},
+	{
+		pattern: 'fixtures/{**/.*,**}',
+		broken: true,
+		issue: 47
 	}
 ]);


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for #226.

### What changes did you make? (Give an overview)

We do not need to try to skip dot directories without applying patterns. The pattern may explicitly includes subdirectories starting with `.`.
