### PR TITLE
ISSUE-239: Destroy source streams when the merged stream is closed 

### DIFF
--- a/src/providers/async.ts
+++ b/src/providers/async.ts
@@ -1,3 +1,5 @@
+import { Readable } from 'stream';
+
 import { Task } from '../managers/tasks';
 import ReaderStream from '../readers/stream';
 import { Entry, EntryItem, ReaderOptions } from '../types';
@@ -21,7 +23,7 @@ export default class ProviderAsync extends Provider<Promise<EntryItem[]>> {
 		});
 	}
 
-	public api(root: string, task: Task, options: ReaderOptions): NodeJS.ReadableStream {
+	public api(root: string, task: Task, options: ReaderOptions): Readable {
 		if (task.dynamic) {
 			return this._reader.dynamic(root, options);
 		}

--- a/src/providers/stream.spec.ts
+++ b/src/providers/stream.spec.ts
@@ -100,5 +100,23 @@ describe('Providers → ProviderStream', () => {
 				done();
 			});
 		});
+
+		it('should destroy source stream when the destination stream is closed', (done) => {
+			const provider = getProvider();
+			const task = tests.task.builder().base('.').positive('*').build();
+			const stream = new PassThrough();
+
+			provider.reader.dynamic.returns(stream);
+
+			const actual = provider.read(task);
+
+			actual.once('close', () => {
+				assert.ok(stream.destroyed);
+
+				done();
+			});
+
+			actual.emit('close');
+		});
 	});
 });

--- a/src/providers/stream.ts
+++ b/src/providers/stream.ts
@@ -20,6 +20,9 @@ export default class ProviderStream extends Provider<Readable> {
 			.on('data', (entry: Entry) => destination.emit('data', options.transform(entry)))
 			.once('end', () => destination.emit('end'));
 
+		destination
+			.once('close', () => source.destroy());
+
 		return destination;
 	}
 

--- a/src/providers/stream.ts
+++ b/src/providers/stream.ts
@@ -5,10 +5,10 @@ import ReaderStream from '../readers/stream';
 import { Entry, ErrnoException, ReaderOptions } from '../types';
 import Provider from './provider';
 
-export default class ProviderStream extends Provider<NodeJS.ReadableStream> {
+export default class ProviderStream extends Provider<Readable> {
 	protected _reader: ReaderStream = new ReaderStream(this._settings);
 
-	public read(task: Task): NodeJS.ReadableStream {
+	public read(task: Task): Readable {
 		const root = this._getRootDirectory(task);
 		const options = this._getReaderOptions(task);
 
@@ -23,7 +23,7 @@ export default class ProviderStream extends Provider<NodeJS.ReadableStream> {
 		return destination;
 	}
 
-	public api(root: string, task: Task, options: ReaderOptions): NodeJS.ReadableStream {
+	public api(root: string, task: Task, options: ReaderOptions): Readable {
 		if (task.dynamic) {
 			return this._reader.dynamic(root, options);
 		}

--- a/src/readers/stream.ts
+++ b/src/readers/stream.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { PassThrough } from 'stream';
+import { PassThrough, Readable } from 'stream';
 
 import * as fsStat from '@nodelib/fs.stat';
 import * as fsWalk from '@nodelib/fs.walk';
@@ -7,15 +7,15 @@ import * as fsWalk from '@nodelib/fs.walk';
 import { Entry, ErrnoException, Pattern, ReaderOptions } from '../types';
 import Reader from './reader';
 
-export default class ReaderStream extends Reader<NodeJS.ReadableStream> {
+export default class ReaderStream extends Reader<Readable> {
 	protected _walkStream: typeof fsWalk.walkStream = fsWalk.walkStream;
 	protected _stat: typeof fsStat.stat = fsStat.stat;
 
-	public dynamic(root: string, options: ReaderOptions): NodeJS.ReadableStream {
+	public dynamic(root: string, options: ReaderOptions): Readable {
 		return this._walkStream(root, options);
 	}
 
-	public static(patterns: Pattern[], options: ReaderOptions): NodeJS.ReadableStream {
+	public static(patterns: Pattern[], options: ReaderOptions): Readable {
 		const filepaths = patterns.map(this._getFullEntryPath, this);
 
 		const stream = new PassThrough({ objectMode: true });

--- a/src/utils/stream.spec.ts
+++ b/src/utils/stream.spec.ts
@@ -9,7 +9,7 @@ describe('Utils → Stream', () => {
 			const first = new stream.PassThrough();
 			const second = new stream.PassThrough();
 
-			const expected = 2;
+			const expected = 3;
 
 			const mergedStream = util.merge([first, second]);
 
@@ -39,6 +39,28 @@ describe('Utils → Stream', () => {
 			first.emit('error', 1);
 			second.emit('error', 2);
 			mergedStream.emit('error', 3);
+		});
+
+		it('should propagate close event to source streams', (done) => {
+			const first = new stream.PassThrough();
+			const second = new stream.PassThrough();
+
+			const mergedStream = util.merge([first, second]);
+
+			const expected = [1, 2];
+
+			const actual: number[] = [];
+
+			first.once('close', () => actual.push(1));
+			second.once('close', () => actual.push(2));
+
+			mergedStream.once('finish', () => {
+				assert.deepStrictEqual(actual, expected);
+
+				done();
+			});
+
+			mergedStream.emit('close');
 		});
 	});
 });

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -9,5 +9,9 @@ export function merge(streams: Readable[]): NodeJS.ReadableStream {
 		stream.once('error', (error) => mergedStream.emit('error', error));
 	});
 
+	mergedStream.once('close', () => {
+		streams.forEach((stream) => stream.emit('close'));
+	});
+
 	return mergedStream;
 }

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,6 +1,8 @@
+import { Readable } from 'stream';
+
 import * as merge2 from 'merge2';
 
-export function merge(streams: NodeJS.ReadableStream[]): NodeJS.ReadableStream {
+export function merge(streams: Readable[]): NodeJS.ReadableStream {
 	const mergedStream = merge2(streams);
 
 	streams.forEach((stream) => {


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for #239.

### What changes did you make? (Give an overview)

 When a merged streams receives a close event, the streams from which it was created are destroyed.