### PR TITLE
ISSUE-156: correctly handle multiple patterns

### DIFF
--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -14,7 +14,7 @@ export default class DeepFilter {
 	}
 
 	private _getMatcher(patterns: Pattern[]): PartialMatcher {
-		return new PartialMatcher(patterns, this._micromatchOptions);
+		return new PartialMatcher(patterns, this._settings, this._micromatchOptions);
 	}
 
 	private _getNegativePatternsRe(patterns: Pattern[]): PatternRe[] {

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -57,13 +57,7 @@ export default class DeepFilter {
 	}
 
 	private _isSkippedByPositivePatterns(entry: Entry, matcher: PartialMatcher): boolean {
-		const filepath = entry.path.replace(/^\.[/\\]/, '');
-
-		const parts = filepath.split('/');
-		const level = parts.length - 1;
-		const part = parts[level];
-
-		return !this._settings.baseNameMatch && !matcher.match(level, part);
+		return !this._settings.baseNameMatch && !matcher.match(entry.path);
 	}
 
 	private _isSkippedByNegativePatterns(entry: Entry, negativeRe: PatternRe[]): boolean {

--- a/src/providers/matchers/matcher.spec.ts
+++ b/src/providers/matchers/matcher.spec.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 
 import * as tests from '../../tests';
 import { Pattern, MicromatchOptions } from '../../types';
+import Settings from '../../settings';
 import Matcher, { PatternInfo } from './matcher';
 
 class TestMatcher extends Matcher {
@@ -11,7 +12,7 @@ class TestMatcher extends Matcher {
 }
 
 function getMatcher(patterns: Pattern[], options: MicromatchOptions = {}): TestMatcher {
-	return new TestMatcher(patterns, options);
+	return new TestMatcher(patterns, new Settings(), options);
 }
 
 describe('Providers → Matchers → Matcher', () => {

--- a/src/providers/matchers/matcher.ts
+++ b/src/providers/matchers/matcher.ts
@@ -1,5 +1,6 @@
 import { Pattern, MicromatchOptions, PatternRe } from '../../types';
 import * as utils from '../../utils';
+import Settings from '../../settings';
 
 export type PatternSegment = StaticPatternSegment | DynamicPatternSegment;
 
@@ -29,7 +30,7 @@ export type PatternInfo = {
 export default abstract class Matcher {
 	protected readonly _storage: PatternInfo[] = [];
 
-	constructor(private readonly _patterns: Pattern[], private readonly _options: MicromatchOptions) {
+	constructor(private readonly _patterns: Pattern[], private readonly _settings: Settings, private readonly _micromatchOptions: MicromatchOptions) {
 		this._fillStorage();
 	}
 
@@ -54,10 +55,10 @@ export default abstract class Matcher {
 	}
 
 	private _getPatternSegments(pattern: Pattern): PatternSegment[] {
-		const parts = utils.pattern.getPatternParts(pattern, this._options);
+		const parts = utils.pattern.getPatternParts(pattern, this._micromatchOptions);
 
 		return parts.map((part) => {
-			const dynamic = utils.pattern.isDynamicPattern(part);
+			const dynamic = utils.pattern.isDynamicPattern(part, this._settings);
 
 			if (!dynamic) {
 				return {
@@ -69,7 +70,7 @@ export default abstract class Matcher {
 			return {
 				dynamic: true,
 				pattern: part,
-				patternRe: utils.pattern.makeRe(part, this._options)
+				patternRe: utils.pattern.makeRe(part, this._micromatchOptions)
 			};
 		});
 	}

--- a/src/providers/matchers/partial.spec.ts
+++ b/src/providers/matchers/partial.spec.ts
@@ -7,49 +7,50 @@ function getMatcher(patterns: Pattern[], options: MicromatchOptions = {}): Match
 	return new Matcher(patterns, options);
 }
 
-function assertMatch(patterns: Pattern[], level: number, part: string): void | never {
+function assertMatch(patterns: Pattern[], filepath: string): void | never {
 	const matcher = getMatcher(patterns);
 
-	assert.ok(matcher.match(level, part));
+	assert.ok(matcher.match(filepath), `Path "${filepath}" should match: ${patterns}`);
 }
 
-function assertNotMatch(patterns: Pattern[], level: number, part: string): void | never {
+function assertNotMatch(patterns: Pattern[], filepath: string): void | never {
 	const matcher = getMatcher(patterns);
 
-	assert.ok(!matcher.match(level, part));
+	assert.ok(!matcher.match(filepath), `Path "${filepath}" should do not match: ${patterns}`);
 }
 
 describe('Providers → Matchers → Partial', () => {
 	describe('.match', () => {
 		it('should handle patterns with globstar', () => {
-			assertMatch(['**'], 0, 'a');
-			assertMatch(['**'], 1, 'b');
-			assertMatch(['**/a'], 0, 'a');
-			assertMatch(['**/a'], 1, 'a');
-			assertNotMatch(['a/**'], 0, 'b');
-			assertMatch(['a/**'], 1, 'b');
+			assertMatch(['**'], 'a');
+			assertMatch(['**'], './a');
+			assertMatch(['**/a'], 'a');
+			assertMatch(['**/a'], 'b/a');
+			assertMatch(['a/**'], 'a/b');
+			assertNotMatch(['a/**'], 'b');
 		});
 
 		it('should do not match the latest segment', () => {
-			assertMatch(['b', 'b/*'], 0, 'b');
-			assertNotMatch(['*'], 0, 'a');
-			assertNotMatch(['a/*'], 1, 'b');
+			assertMatch(['b/*'], 'b');
+			assertNotMatch(['*'], 'a');
+			assertNotMatch(['a/*'], 'a/b');
 		});
 
 		it('should trying to match all patterns', () => {
-			assertMatch(['a/*', 'b/*'], 0, 'b');
-			assertMatch(['non-match', 'a/*/c'], 1, 'b');
+			assertMatch(['a/*', 'b/*'], 'b');
+			assertMatch(['non-match/b/c', 'a/*/c'], 'a/b');
+			assertNotMatch(['non-match/d/c', 'a/b/c'], 'a/d');
 		});
 
 		it('should match a static segment', () => {
-			assertMatch(['a/b'], 0, 'a');
-			assertNotMatch(['b/b'], 0, 'a');
+			assertMatch(['a/b'], 'a');
+			assertNotMatch(['b/b'], 'a');
 		});
 
 		it('should match a dynamic segment', () => {
-			assertMatch(['*/b'], 0, 'a');
-			assertMatch(['{a,b}/*'], 0, 'a');
-			assertNotMatch(['{a,b}/*'], 0, 'c');
+			assertMatch(['*/b'], 'a');
+			assertMatch(['{a,b}/*'], 'a');
+			assertNotMatch(['{a,b}/*'], 'c');
 		});
 	});
 });

--- a/src/providers/matchers/partial.spec.ts
+++ b/src/providers/matchers/partial.spec.ts
@@ -1,10 +1,11 @@
 import * as assert from 'assert';
 
 import { Pattern, MicromatchOptions } from '../../types';
+import Settings from '../../settings';
 import Matcher from './partial';
 
 function getMatcher(patterns: Pattern[], options: MicromatchOptions = {}): Matcher {
-	return new Matcher(patterns, options);
+	return new Matcher(patterns, new Settings(), options);
 }
 
 function assertMatch(patterns: Pattern[], filepath: string): void | never {

--- a/src/providers/matchers/partial.spec.ts
+++ b/src/providers/matchers/partial.spec.ts
@@ -38,6 +38,7 @@ describe('Providers → Matchers → Partial', () => {
 
 		it('should trying to match all patterns', () => {
 			assertMatch(['a/*', 'b/*'], 0, 'b');
+			assertMatch(['non-match', 'a/*/c'], 1, 'b');
 		});
 
 		it('should match a static segment', () => {

--- a/src/providers/matchers/partial.ts
+++ b/src/providers/matchers/partial.ts
@@ -17,13 +17,15 @@ export default class PartialMatcher extends Matcher {
 			}
 
 			/**
-			 * When size of the first group (minus the latest segment) equals to `level`, we do not need reading the next directory,
-			 * because in the next iteration, the path will have more levels than the pattern.
+			 * When size of the first group (minus the latest segment) greater or equals to `level`,
+			 * we do not need reading the next directory, because in the next iteration,
+			 * the path will have more levels than the pattern.
+			 *
 			 * But only if the pattern doesn't have a globstar (we must read all directories).
 			 *
 			 * In this cases we must trying to match other patterns.
 			 */
-			if (info.complete && level === section.length - 1) {
+			if (info.complete && level >= section.length - 1) {
 				continue;
 			}
 

--- a/src/providers/matchers/partial.ts
+++ b/src/providers/matchers/partial.ts
@@ -1,9 +1,14 @@
 import Matcher from './matcher';
 
 export default class PartialMatcher extends Matcher {
-	public match(level: number, part: string): boolean {
-		for (const info of this._storage) {
-			const section = info.sections[0];
+	public match(filepath: string): boolean {
+		const parts = filepath.split('/');
+		const levels = parts.length;
+
+		const patterns = this._storage.filter((info) => !info.complete || info.segments.length > levels);
+
+		for (const pattern of patterns) {
+			const section = pattern.sections[0];
 
 			/**
 			 * In this case, the pattern has a globstar and we must read all directories unconditionally,
@@ -12,30 +17,25 @@ export default class PartialMatcher extends Matcher {
 			 * fixtures/{a,b}/**
 			 *  ^ true/false  ^ always true
 			*/
-			if (!info.complete && level >= section.length) {
+			if (!pattern.complete && levels > section.length) {
 				return true;
 			}
 
-			/**
-			 * When size of the first group (minus the latest segment) greater or equals to `level`,
-			 * we do not need reading the next directory, because in the next iteration,
-			 * the path will have more levels than the pattern.
-			 *
-			 * But only if the pattern doesn't have a globstar (we must read all directories).
-			 *
-			 * In this cases we must trying to match other patterns.
-			 */
-			if (info.complete && level >= section.length - 1) {
-				continue;
-			}
+			const match = parts.every((part, index) => {
+				const segment = pattern.segments[index];
 
-			const segment = section[level];
+				if (segment.dynamic && segment.patternRe.test(part)) {
+					return true;
+				}
 
-			if (segment.dynamic && segment.patternRe.test(part)) {
-				return true;
-			}
+				if (!segment.dynamic && segment.pattern === part) {
+					return true;
+				}
 
-			if (!segment.dynamic && segment.pattern === part) {
+				return false;
+			});
+
+			if (match) {
 				return true;
 			}
 		}

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -24,6 +24,10 @@ describe('Utils → Pattern', () => {
 				assert.ok(util.isDynamicPattern('\\'));
 			});
 
+			it('should return true for everything when the `caseSensitiveMatch` option is disabled', () => {
+				assert.ok(util.isDynamicPattern('abc', { caseSensitiveMatch: false }));
+			});
+
 			it('should return true for patterns that include common glob symbols', () => {
 				assert.ok(util.isDynamicPattern('*'));
 				assert.ok(util.isDynamicPattern('abc/*'));
@@ -59,12 +63,30 @@ describe('Utils → Pattern', () => {
 				assert.ok(util.isDynamicPattern('+(a|b)'));
 			});
 
+			it('should return false for glob extension when the `extglob` option is disabled', () => {
+				assert.ok(!util.isDynamicPattern('@()', { extglob: false }));
+				assert.ok(!util.isDynamicPattern('@(a)', { extglob: false }));
+				assert.ok(!util.isDynamicPattern('@(a|b)', { extglob: false }));
+				assert.ok(!util.isDynamicPattern('abc/!(a|b)', { extglob: false }));
+				assert.ok(util.isDynamicPattern('*(a|b)', { extglob: true }));
+				assert.ok(util.isDynamicPattern('?(a|b)', { extglob: true }));
+				assert.ok(!util.isDynamicPattern('+(a|b)', { extglob: false }));
+			});
+
 			it('should return true for patterns that include brace expansions symbols', () => {
 				assert.ok(util.isDynamicPattern('{,}'));
 				assert.ok(util.isDynamicPattern('{a,}'));
 				assert.ok(util.isDynamicPattern('{,b}'));
 				assert.ok(util.isDynamicPattern('{a,b}'));
 				assert.ok(util.isDynamicPattern('{1..3}'));
+			});
+
+			it('should return false for brace extension when the `braceExpansion` option is disabled', () => {
+				assert.ok(!util.isDynamicPattern('{,}', { braceExpansion: false }));
+				assert.ok(!util.isDynamicPattern('{a,}', { braceExpansion: false }));
+				assert.ok(!util.isDynamicPattern('{,b}', { braceExpansion: false }));
+				assert.ok(!util.isDynamicPattern('{a,b}', { braceExpansion: false }));
+				assert.ok(!util.isDynamicPattern('{1..3}', { braceExpansion: false }));
 			});
 
 			it('should return false for "!" symbols when a symbol is not specified first in the string', () => {

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -303,42 +303,6 @@ describe('Utils → Pattern', () => {
 		});
 	});
 
-	describe('.getNaiveDepth', () => {
-		it('should return 0', () => {
-			const expected = 0; // 1 (pattern) - 1 (base directory)
-
-			const actual = util.getNaiveDepth('*.js');
-
-			assert.strictEqual(actual, expected);
-		});
-
-		it('should returns 1', () => {
-			const expected = 1; // 4 (pattern) - 2 (base directory) - 1
-
-			const actual = util.getNaiveDepth('a/b/*/*.js');
-
-			assert.strictEqual(actual, expected);
-		});
-	});
-
-	describe('.getMaxNaivePatternsDepth', () => {
-		it('should return 1', () => {
-			const expected = 1;
-
-			const actual = util.getMaxNaivePatternsDepth(['*.js', './*.js']);
-
-			assert.strictEqual(actual, expected);
-		});
-
-		it('should return 2', () => {
-			const expected = 2;
-
-			const actual = util.getMaxNaivePatternsDepth(['*.js', './*/*.js']);
-
-			assert.strictEqual(actual, expected);
-		});
-	});
-
 	describe('.expandPatternsWithBraceExpansion', () => {
 		it('should return an array of expanded patterns with brace expansion', () => {
 			const expected = ['a/b/d', 'a/c/d', 'a/*', 'a/b/c'];

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -90,32 +90,6 @@ export function isAffectDepthOfReadingPattern(pattern: Pattern): boolean {
 	return endsWithSlashGlobStar(pattern) || isStaticPattern(basename);
 }
 
-export function getNaiveDepth(pattern: Pattern): number {
-	const base = getBaseDirectory(pattern);
-
-	const patternDepth = pattern.split('/').length;
-	const patternBaseDepth = base.split('/').length;
-
-	/**
-	 * This is a hack for pattern that has no base directory.
-	 *
-	 * This is related to the `*\something\*` pattern.
-	 */
-	if (base === '.') {
-		return patternDepth - patternBaseDepth;
-	}
-
-	return patternDepth - patternBaseDepth - 1;
-}
-
-export function getMaxNaivePatternsDepth(patterns: Pattern[]): number {
-	return patterns.reduce((max, pattern) => {
-		const depth = getNaiveDepth(pattern);
-
-		return depth > max ? depth : max;
-	}, 0);
-}
-
 export function expandPatternsWithBraceExpansion(patterns: Pattern[]): Pattern[] {
 	return patterns.reduce((collection, pattern) => {
 		return collection.concat(expandBraceExpansion(pattern));


### PR DESCRIPTION
### What is the purpose of this pull request?

Not the partial matcher has a bug: matcher does not check the previous state for parts of the pattern.

```
patterns: ['a/b/c', 'b/d/c']

match 'a/b' → ok by 'a/b/c'
match 'a/d' → ok by 'b/d/c', but must not be ok
```

### What changes did you make? (Give an overview)

* Check the previous state for each part of the filepath.
