### PR TITLE
ISSUE-253: avoid problem with micromatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "@nodelib/fs.walk": "^1.2.3",
     "glob-parent": "^5.1.0",
     "merge2": "^1.3.0",
-    "micromatch": "^4.0.2"
+    "micromatch": "^4.0.2",
+    "picomatch": "^2.2.1"
   },
   "scripts": {
     "clean": "rimraf out",


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a temporary fix for #253.

### What changes did you make? (Give an overview)

* Add the `picomatch` package as dependency to avoid problem with outdated `picomatch` version in the `micromatch` package.