### PR TITLE
ISSUE-257: Fix problem with patterns with leading dot segment

### DIFF
--- a/src/providers/filters/deep.spec.ts
+++ b/src/providers/filters/deep.spec.ts
@@ -87,7 +87,7 @@ describe('Providers → Filters → Deep', () => {
 			});
 
 			it('should return `false` when an entry starts with "./" and does not match to the positive pattern', () => {
-				const filter = getFilter('.', ['non-root/directory'], []);
+				const filter = getFilter('.', ['non-root/*'], []);
 				const entry = tests.entry.builder().path('./root').directory().build();
 
 				const actual = filter(entry);
@@ -95,7 +95,16 @@ describe('Providers → Filters → Deep', () => {
 				assert.ok(!actual);
 			});
 
-			it('should return `true` when the positive pattern does not match, but the `baseNameMatch` is enabled', () => {
+			it('should return `true` when an entry match to the positive pattern with leading dot', () => {
+				const filter = getFilter('.', ['./root/*'], []);
+				const entry = tests.entry.builder().path('./root').directory().build();
+
+				const actual = filter(entry);
+
+				assert.ok(actual);
+			});
+
+			it('should return `true` when the positive pattern does not match by level, but the `baseNameMatch` is enabled', () => {
 				const filter = getFilter('.', ['*'], [], { baseNameMatch: true });
 				const entry = tests.entry.builder().path('root/directory').directory().build();
 

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -57,7 +57,9 @@ export default class DeepFilter {
 	}
 
 	private _isSkippedByPositivePatterns(entry: Entry, matcher: PartialMatcher): boolean {
-		return !this._settings.baseNameMatch && !matcher.match(entry.path);
+		const filepath = entry.path.replace(/^\.[/\\]/, '');
+
+		return !this._settings.baseNameMatch && !matcher.match(filepath);
 	}
 
 	private _isSkippedByNegativePatterns(entry: Entry, negativeRe: PatternRe[]): boolean {

--- a/src/providers/filters/deep.ts
+++ b/src/providers/filters/deep.ts
@@ -34,11 +34,13 @@ export default class DeepFilter {
 			return false;
 		}
 
-		if (this._isSkippedByPositivePatterns(entry, matcher)) {
+		const filepath = utils.path.removeLeadingDotSegment(entry.path);
+
+		if (this._isSkippedByPositivePatterns(filepath, matcher)) {
 			return false;
 		}
 
-		return this._isSkippedByNegativePatterns(entry, negativeRe);
+		return this._isSkippedByNegativePatterns(filepath, negativeRe);
 	}
 
 	private _isSkippedByDeep(entryDepth: number): boolean {
@@ -56,13 +58,11 @@ export default class DeepFilter {
 		return entryPathDepth - (basePath === '' ? 0 : basePathDepth);
 	}
 
-	private _isSkippedByPositivePatterns(entry: Entry, matcher: PartialMatcher): boolean {
-		const filepath = entry.path.replace(/^\.[/\\]/, '');
-
-		return !this._settings.baseNameMatch && !matcher.match(filepath);
+	private _isSkippedByPositivePatterns(entryPath: string, matcher: PartialMatcher): boolean {
+		return !this._settings.baseNameMatch && !matcher.match(entryPath);
 	}
 
-	private _isSkippedByNegativePatterns(entry: Entry, negativeRe: PatternRe[]): boolean {
-		return !utils.pattern.matchAny(entry.path, negativeRe);
+	private _isSkippedByNegativePatterns(entryPath: string, negativeRe: PatternRe[]): boolean {
+		return !utils.pattern.matchAny(entryPath, negativeRe);
 	}
 }

--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -161,6 +161,15 @@ describe('Providers → Filters → Entry', () => {
 				assert.ok(!actual);
 			});
 
+			it('should return `true` when an entry match to the positive pattern with leading dot', () => {
+				const filter = getFilter(['./**/*'], []);
+				const entry = tests.entry.builder().path('./root/file.txt').file().build();
+
+				const actual = filter(entry);
+
+				assert.ok(actual);
+			});
+
 			it('should return `true` when an entry match to the positive pattern', () => {
 				const filter = getFilter(['**/*'], []);
 				const entry = tests.entry.builder().path('root/file.txt').file().build();

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -62,7 +62,9 @@ export default class EntryFilter {
 		return this._isMatchToPatterns(fullpath, negativeRe);
 	}
 
-	private _isMatchToPatterns(filepath: string, patternsRe: PatternRe[]): boolean {
+	private _isMatchToPatterns(entryPath: string, patternsRe: PatternRe[]): boolean {
+		const filepath = utils.path.removeLeadingDotSegment(entryPath);
+
 		return utils.pattern.matchAny(filepath, patternsRe);
 	}
 }

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -54,4 +54,23 @@ describe('Utils → Path', () => {
 			assert.strictEqual(util.escape('abc@'), 'abc@');
 		});
 	});
+
+	describe('.removeLeadingDotCharacters', () => {
+		it('should return path without changes', () => {
+			assert.strictEqual(util.removeLeadingDotSegment('../a/b'), '../a/b');
+			assert.strictEqual(util.removeLeadingDotSegment('~/a/b'), '~/a/b');
+			assert.strictEqual(util.removeLeadingDotSegment('/a/b'), '/a/b');
+			assert.strictEqual(util.removeLeadingDotSegment('a/b'), 'a/b');
+
+			assert.strictEqual(util.removeLeadingDotSegment('..\\a\\b'), '..\\a\\b');
+			assert.strictEqual(util.removeLeadingDotSegment('~\\a\\b'), '~\\a\\b');
+			assert.strictEqual(util.removeLeadingDotSegment('\\a\\b'), '\\a\\b');
+			assert.strictEqual(util.removeLeadingDotSegment('a\\b'), 'a\\b');
+		});
+
+		it('should return path without leading dit characters', () => {
+			assert.strictEqual(util.removeLeadingDotSegment('./a/b'), 'a/b');
+			assert.strictEqual(util.removeLeadingDotSegment('.\\a\\b'), 'a\\b');
+		});
+	});
 });

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 
 import { Pattern } from '../types';
 
+const LEADING_DOT_SEGMENT_CHARACTERS_COUNT = 2; // ./ or .\\
 const UNESCAPED_GLOB_SYMBOLS_RE = /(\\?)([()*?[\]{|}]|^!|[!+@](?=\())/g;
 
 /**
@@ -17,4 +18,18 @@ export function makeAbsolute(cwd: string, filepath: string): string {
 
 export function escape(pattern: Pattern): Pattern {
 	return pattern.replace(UNESCAPED_GLOB_SYMBOLS_RE, '\\$2');
+}
+
+export function removeLeadingDotSegment(entry: string): string {
+	// We do not use `startsWith` because this is 10x slower than current implementation for some cases.
+	// eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
+	if (entry.charAt(0) === '.') {
+		const secondCharactery = entry.charAt(1);
+
+		if (secondCharactery === '/' || secondCharactery === '\\') {
+			return entry.slice(LEADING_DOT_SEGMENT_CHARACTERS_COUNT);
+		}
+	}
+
+	return entry;
 }

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -399,13 +399,5 @@ describe('Utils → Pattern', () => {
 
 			assert.ok(!actual);
 		});
-
-		it('should return true for path with leading slash', () => {
-			const pattern = util.makeRe('*.js', {});
-
-			const actual = util.matchAny('./test.js', [pattern]);
-
-			assert.ok(actual);
-		});
 	});
 });

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -127,7 +127,5 @@ export function convertPatternsToRe(patterns: Pattern[], options: MicromatchOpti
 }
 
 export function matchAny(entry: string, patternsRe: PatternRe[]): boolean {
-	const filepath = entry.replace(/^\.[/\\]/, '');
-
-	return patternsRe.some((patternRe) => patternRe.test(filepath));
+	return patternsRe.some((patternRe) => patternRe.test(entry));
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for the second problem from issue #257.

### What changes did you make? (Give an overview)

```
# ../a/b/c/d/e/f/package.json
  regex x 23,178,409 ops/sec ±1.35% (91 runs sampled)
  implementation x 154,058,251 ops/sec ±0.53% (92 runs sampled)
  startsWith x 13,509,321 ops/sec ±0.42% (90 runs sampled)
  startsWith2 x 75,557,551 ops/sec ±8.15% (65 runs sampled))

# ./a/b/c/d/e/f/package.json
  regex x 8,994,021 ops/sec ±8.46% (54 runs sampled))
  implementation x 198,810,564 ops/sec ±13.27% (61 runs sampled)
  startsWith x 16,207,750 ops/sec ±12.35% (51 runs sampled)
  startsWith2 x 99,489,385 ops/sec ±1.63% (84 runs sampled))

# /a/b/c/d/e/f/package.json
  regex x 16,868,716 ops/sec ±2.26% (82 runs sampled)
  implementation x 477,864,318 ops/sec ±1.72% (83 runs sampled)
  startsWith x 14,659,336 ops/sec ±1.16% (86 runs sampled)
  startsWith2 x 158,053,865 ops/sec ±0.61% (94 runs sampled)

# a/b/c/d/e/f/package.json
  regex x 20,893,710 ops/sec ±1.48% (87 runs sampled)
  implementation x 497,356,643 ops/sec ±0.49% (91 runs sampled)
  startsWith x 13,276,911 ops/sec ±1.87% (82 runs sampled)
  startsWith2 x 158,630,305 ops/sec ±0.77% (89 runs sampled)

# .\a/b/c/d/e/f/package.json
  regex x 14,714,964 ops/sec ±1.92% (85 runs sampled)
  implementation x 233,973,873 ops/sec ±0.46% (90 runs sampled)
  startsWith x 16,131,011 ops/sec ±1.03% (92 runs sampled)
  startsWith2 x 108,967,722 ops/sec ±0.71% (87 runs sampled)

# ~/a/b/c/d/e/f/package.json
  regex x 21,441,101 ops/sec ±0.97% (92 runs sampled)
  implementation x 500,961,106 ops/sec ±0.38% (93 runs sampled)
  startsWith x 14,958,186 ops/sec ±0.81% (93 runs sampled)
  startsWith2 x 161,539,931 ops/sec ±0.27% (96 runs sampled)
```