### PR TITLE
ISSUE-266: Correctly split pattern with a forward slash into parts

### DIFF
--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -346,7 +346,7 @@ describe('Utils → Pattern', () => {
 	});
 
 	describe('.getPatternParts', () => {
-		it('should return an array with a single item with an empty string', () => {
+		it('should return an array with a single item when the pattern is an empty string', () => {
 			const expected: Pattern[] = [''];
 
 			const actual = util.getPatternParts('', {});
@@ -358,6 +358,14 @@ describe('Utils → Pattern', () => {
 			const expected: Pattern[] = ['a*'];
 
 			const actual = util.getPatternParts('a*', {});
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should return the correct set of parts for the pattern with a forward slash (micromatch/picomatch#58)', () => {
+			const expected: Pattern[] = ['', 'lib', '*'];
+
+			const actual = util.getPatternParts('/lib/*', {});
 
 			assert.deepStrictEqual(actual, expected);
 		});

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -105,17 +105,29 @@ export function expandBraceExpansion(pattern: Pattern): Pattern[] {
 }
 
 export function getPatternParts(pattern: Pattern, options: MicromatchOptions): Pattern[] {
-	const info = picomatch.scan(pattern, {
+	let { parts } = picomatch.scan(pattern, {
 		...options,
 		parts: true
 	});
 
-	// See micromatch/picomatch#58 for more details
-	if (info.parts.length === 0) {
-		return [pattern];
+	/**
+	 * The scan method returns an empty array in some cases.
+	 * See micromatch/picomatch#58 for more details.
+	 */
+	if (parts.length === 0) {
+		parts = [pattern];
 	}
 
-	return info.parts;
+	/**
+	 * The scan method does not return an empty part for the pattern with a forward slash.
+	 * This is another part of micromatch/picomatch#58.
+	 */
+	if (parts[0].startsWith('/')) {
+		parts[0] = parts[0].slice(1);
+		parts.unshift('');
+	}
+
+	return parts;
 }
 
 export function makeRe(pattern: Pattern, options: MicromatchOptions): PatternRe {


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for #266.

### What changes did you make? (Give an overview)

The `scan` method in the `picomatch` dependency returns the `['/lib']` part instead of `['', 'lib']`.