### PR TITLE
ISSUE-276: Regression in the new version (3.2.3) when using the caseSensitiveMatch option is disabled

### DIFF
--- a/src/tests/smoke/case-sensitive-match.smoke.ts
+++ b/src/tests/smoke/case-sensitive-match.smoke.ts
@@ -1,3 +1,5 @@
+import * as os from 'os';
+
 import * as smoke from './smoke';
 
 smoke.suite('Smoke → CaseSensitiveMatch', [
@@ -8,5 +10,13 @@ smoke.suite('Smoke → CaseSensitiveMatch', [
 		pattern: 'fixtures/File.md',
 		globOptions: { nocase: true },
 		fgOptions: { caseSensitiveMatch: false }
+	},
+
+	// ISSUE-276
+	{
+		pattern: '/tmp/*',
+		globOptions: { nocase: true, nodir: false },
+		fgOptions: { caseSensitiveMatch: false, onlyFiles: false },
+		condition: () => os.platform() !== 'win32'
 	}
 ]);

--- a/src/tests/smoke/regular.smoke.ts
+++ b/src/tests/smoke/regular.smoke.ts
@@ -1,3 +1,5 @@
+import * as os from 'os';
+
 import * as smoke from './smoke';
 
 smoke.suite('Smoke → Regular', [
@@ -482,4 +484,9 @@ smoke.suite('Smoke → Regular (relative)', [
 
 	{ pattern: '../{first,second}', cwd: 'fixtures/first' },
 	{ pattern: './../*', cwd: 'fixtures/first' }
+]);
+
+smoke.suite('Smoke → Regular (root)', [
+	// ISSUE-266
+	{ pattern: '/tmp/*', condition: () => os.platform() !== 'win32' }
 ]);

--- a/src/tests/smoke/smoke.ts
+++ b/src/tests/smoke/smoke.ts
@@ -28,6 +28,10 @@ export type SmokeTest = {
 	 */
 	correct?: boolean;
 	reason?: string;
+	/**
+	 * The ability to conditionally run the test.
+	 */
+	condition?: () => boolean;
 };
 
 type MochaDefinition = Mocha.TestFunction | Mocha.ExclusiveTestFunction;
@@ -71,7 +75,15 @@ function getTestCaseTitle(test: SmokeTest): string {
 }
 
 function getTestCaseMochaDefinition(test: SmokeTest): MochaDefinition {
-	return test.debug === true ? it.only : it;
+	if (test.debug === true) {
+		return it.only;
+	}
+
+	if (test.condition?.() === false) {
+		return it.skip;
+	}
+
+	return it;
 }
 
 async function testCaseRunner(test: SmokeTest, func: typeof getFastGlobEntriesSync | typeof getFastGlobEntriesAsync): Promise<void> {

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -20,6 +20,10 @@ describe('Utils → Pattern', () => {
 
 	describe('.isDynamicPattern', () => {
 		describe('Without options', () => {
+			it('should return false for an empty string', () => {
+				assert.ok(!util.isDynamicPattern(''));
+			});
+
 			it('should return true for patterns that include the escape symbol', () => {
 				assert.ok(util.isDynamicPattern('\\'));
 			});

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -27,6 +27,15 @@ export function isStaticPattern(pattern: Pattern, options: PatternTypeOptions = 
 
 export function isDynamicPattern(pattern: Pattern, options: PatternTypeOptions = {}): boolean {
 	/**
+	 * A special case with an empty string is necessary for matching patterns that start with a forward slash.
+	 * An empty string cannot be a dynamic pattern.
+	 * For example, the pattern `/lib/*` will be spread into parts: '', 'lib', '*'.
+	 */
+	if (pattern === '') {
+		return false;
+	}
+
+	/**
 	 * When the `caseSensitiveMatch` option is disabled, all patterns must be marked as dynamic, because we cannot check
 	 * filepath directly (without read directory).
 	 */


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for #276.

### What changes did you make? (Give an overview)

Correctly handle an empty string in `isDynamicPattern` method.