### PR TITLE
DISCUSSION: Construct negative patterns for single trailing `*`

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -11,7 +11,7 @@ describe('Managers → Task', () => {
 			const settings = new Settings({ ignore: ['*.txt'] });
 
 			const expected = [
-				tests.task.builder().base('a').positive('a/*').negative('*.md').negative('*.txt').build()
+				tests.task.builder().base('a').positive('a/*').negative('*.md').negative('*.txt').negative('a/*.txt').build()
 			];
 
 			const actual = manager.generate(['a/*', '!*.md'], settings);
@@ -23,8 +23,8 @@ describe('Managers → Task', () => {
 			const settings = new Settings({ ignore: ['*.txt'] });
 
 			const expected = [
-				tests.task.builder().base('a').static().positive('a/file.json').negative('b/*.md').negative('*.txt').build(),
-				tests.task.builder().base('b').positive('b/*').negative('b/*.md').negative('*.txt').build()
+				tests.task.builder().base('a').static().positive('a/file.json').negative('b/*.md').negative('*.txt').negative('b/*.txt').build(),
+				tests.task.builder().base('b').positive('b/*').negative('b/*.md').negative('*.txt').negative('b/*.txt').build()
 			];
 
 			const actual = manager.generate(['a/file.json', 'b/*', '!b/*.md'], settings);

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -41,8 +41,16 @@ export function getPositivePatterns(patterns: Pattern[]): Pattern[] {
 	return utils.pattern.getPositivePatterns(patterns);
 }
 
-export function getNegativePatternsAsPositive(patterns: Pattern[], ignore: Pattern[]): Pattern[] {
-	const negative = utils.pattern.getNegativePatterns(patterns).concat(ignore);
+export function getNegativePatternsAsPositive(patterns: Pattern[], ignores: Pattern[]): Pattern[] {
+	const re = /\/\*$/;
+	const negative = utils.pattern.getNegativePatterns(patterns.filter((x) => re.exec(x) === null)).concat(ignores);
+
+	for (const pattern of patterns.filter((x) => re.exec(x) !== null)) {
+		for (const ignore of ignores) {
+			negative.push(pattern.slice(0, Math.max(0, pattern.length - 1)) + ignore);
+		}
+	}
+
 	const positive = negative.map(utils.pattern.convertToPositivePattern);
 
 	return positive;


### PR DESCRIPTION
When given arguments similar to:

  ['a/*', 'b/*'], { ignore: ['*.c', '*.d'] }

add the following to the negative patterns listing:

  'a/*.c'
  'a/*.d'
  'b/*.c'
  'b/*.d'

to allow ignoring patterns at a specific depth