### PR TITLE
Keep dynamic patterns in their own groups

### DIFF
--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -25,15 +25,6 @@ export function generate(patterns: Pattern[], settings: Settings): Task[] {
 
 export function convertPatternsToTasks(positive: Pattern[], negative: Pattern[], dynamic: boolean): Task[] {
 	const positivePatternsGroup = groupPatternsByBaseDirectory(positive);
-
-	// When we have a global group – there is no reason to divide the patterns into independent tasks.
-	// In this case, the global task covers the rest.
-	if ('.' in positivePatternsGroup) {
-		const task = convertPatternGroupToTask('.', positive, negative, dynamic);
-
-		return [task];
-	}
-
 	return convertPatternGroupsToTasks(positivePatternsGroup, negative, dynamic);
 }
 


### PR DESCRIPTION
If using multiple dynamic patterns where some point out to ../ and others
would be in the '.' group, all are added to this group, but the file
walker can't get out of the base directory and not all files are found.

### What is the purpose of this pull request?
Addresses #316

### What changes did you make? (Give an overview)
Removed the '.' task group, as it can't contain patterns that point to places outside the base directory.

It would be possible to solve in a different way, by looking for ../ patterns, but I'm not sure if there are more cases where that could be a problem. Is having multiple task groups going to be a performance problem?

I did not create tests, as I didn't find any that work against a list of patterns. Maybe I missed them?
