### PR TITLE
Upgraded glob-parent beyond vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@nodelib/fs.stat": "^2.0.2",
     "@nodelib/fs.walk": "^1.2.3",
-    "glob-parent": "^5.1.2",
+    "glob-parent": "^6.0.0",
     "merge2": "^1.3.0",
     "micromatch": "^4.0.4"
   },


### PR DESCRIPTION
### What is the purpose of this pull request?
[glob-parent security vulnerability ](https://www.npmjs.com/advisories/1751)in v5.1.2 is preventing a package I use from being published

### What changes did you make? (Give an overview)
Upgrade glob-parent to 6.0 and ran tests to confirm is still works
