### PR TITLE
ISSUE-316: fix support for mixed base directories

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -57,7 +57,20 @@ describe('Managers → Task', () => {
 			assert.deepStrictEqual(actual, expected);
 		});
 
-		it('should return two tasks', () => {
+		it('should return two tasks when one of patterns contains reference to the parent directory', () => {
+			const expected = [
+				tests.task.builder().base('..').positive('../*.md').build(),
+				tests.task.builder().base('.').positive('*').positive('a/*').negative('*.md').build()
+			];
+
+			const actual = manager.convertPatternsToTasks(['*', 'a/*', '../*.md'], ['*.md'], /* dynamic */ true);
+
+			console.dir(actual, { colors: true });
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should return two tasks when all patterns refers to the different base directories', () => {
 			const expected = [
 				tests.task.builder().base('a').positive('a/*').negative('b/*.md').build(),
 				tests.task.builder().base('b').positive('b/*').negative('b/*.md').build()

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -257,6 +257,52 @@ describe('Utils → Pattern', () => {
 		});
 	});
 
+	describe('.getPatternsInsideCurrentDirectory', () => {
+		it('should return patterns', () => {
+			const expected: Pattern[] = ['.', './*', '*', 'a/*'];
+
+			const actual = util.getPatternsInsideCurrentDirectory(['.', './*', '*', 'a/*', '..', '../*', './..', './../*']);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+	});
+
+	describe('.getPatternsOutsideCurrentDirectory', () => {
+		it('should return patterns', () => {
+			const expected: Pattern[] = ['..', '../*', './..', './../*'];
+
+			const actual = util.getPatternsOutsideCurrentDirectory(['.', './*', '*', 'a/*', '..', '../*', './..', './../*']);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+	});
+
+	describe('.isPatternRelatedToParentDirectory', () => {
+		it('should be `false` when the pattern refers to the current directory', () => {
+			const actual = util.isPatternRelatedToParentDirectory('.');
+
+			assert.ok(!actual);
+		});
+
+		it('should be `true` when the pattern equals to `..`', () => {
+			const actual = util.isPatternRelatedToParentDirectory('..');
+
+			assert.ok(actual);
+		});
+
+		it('should be `true` when the pattern starts with `..` segment', () => {
+			const actual = util.isPatternRelatedToParentDirectory('../*');
+
+			assert.ok(actual);
+		});
+
+		it('should be `true` when the pattern starts with `./..` segment', () => {
+			const actual = util.isPatternRelatedToParentDirectory('./../*');
+
+			assert.ok(actual);
+		});
+	});
+
 	describe('.getBaseDirectory', () => {
 		it('should returns base directory', () => {
 			const expected = 'root';

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -81,6 +81,32 @@ export function getPositivePatterns(patterns: Pattern[]): Pattern[] {
 	return patterns.filter(isPositivePattern);
 }
 
+/**
+ * Returns patterns that can be applied inside the current directory.
+ *
+ * @example
+ * // ['./*', '*', 'a/*']
+ * getPatternsInsideCurrentDirectory(['./*', '*', 'a/*', '../*', './../*'])
+ */
+export function getPatternsInsideCurrentDirectory(patterns: Pattern[]): Pattern[] {
+	return patterns.filter((pattern) => !isPatternRelatedToParentDirectory(pattern));
+}
+
+/**
+ * Returns patterns to be expanded relative to (outside) the current directory.
+ *
+ * @example
+ * // ['../*', './../*']
+ * getPatternsInsideCurrentDirectory(['./*', '*', 'a/*', '../*', './../*'])
+ */
+export function getPatternsOutsideCurrentDirectory(patterns: Pattern[]): Pattern[] {
+	return patterns.filter(isPatternRelatedToParentDirectory);
+}
+
+export function isPatternRelatedToParentDirectory(pattern: Pattern): boolean {
+	return pattern.startsWith('..') || pattern.startsWith('./..');
+}
+
 export function getBaseDirectory(pattern: Pattern): string {
 	return globParent(pattern, { flipBackslashes: false });
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for #316 and #310.

### What changes did you make? (Give an overview)

Now we do not group patterns to the global task when at least one base directory refers to the parent directory.

Right now we don't support patterns like `{.,..}/../*.md`. We'll leave that for the future due to the complexity of implementation.