### PR TITLE
TRIVIAL: add fdir to product benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-mrmlnc": "^1.1.0",
     "execa": "^2.0.4",
     "fast-glob": "^3.0.4",
+    "fdir": "^5.1.0",
     "glob": "^7.1.4",
     "is-ci": "^2.0.0",
     "log-update": "^4.0.0",

--- a/src/benchmark/suites/product/async/fdir.ts
+++ b/src/benchmark/suites/product/async/fdir.ts
@@ -1,0 +1,26 @@
+import * as path from 'path';
+
+import { fdir as GlobBuilder, PathsOutput } from 'fdir';
+
+import * as utils from '../../../utils';
+
+const CWD = path.join(process.cwd(), process.env.BENCHMARK_BASE_DIR as string);
+const PATTERN = process.env.BENCHMARK_PATTERN as string;
+
+const fdir = new GlobBuilder()
+	.glob(PATTERN)
+	.crawl(CWD);
+
+const timeStart = utils.timeStart();
+
+fdir.withPromise()
+	.then((matches) => {
+		const memory = utils.getMemory();
+		const time = utils.timeEnd(timeStart);
+		const measures = utils.formatMeasures((matches as PathsOutput).length, time, memory);
+
+		console.info(measures);
+	})
+	.catch(() => {
+		process.exit(0);
+	});

--- a/src/benchmark/suites/product/sync/fdir.ts
+++ b/src/benchmark/suites/product/sync/fdir.ts
@@ -1,0 +1,25 @@
+import * as path from 'path';
+
+import { fdir as GlobBuilder, PathsOutput } from 'fdir';
+
+import * as utils from '../../../utils';
+
+const CWD = path.join(process.cwd(), process.env.BENCHMARK_BASE_DIR as string);
+const PATTERN = process.env.BENCHMARK_PATTERN as string;
+
+const glob = new GlobBuilder()
+	.glob(PATTERN)
+	.crawl(CWD);
+
+const timeStart = utils.timeStart();
+
+try {
+	const matches = glob.sync() as PathsOutput;
+	const memory = utils.getMemory();
+	const time = utils.timeEnd(timeStart);
+	const measures = utils.formatMeasures(matches.length, time, memory);
+
+	console.info(measures);
+} catch {
+	process.exit(0);
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

I've been following this project for a long time. It seems to be getting stronger. Add it to product benchmark.

The fdir has a pretty fast directory tree traversal, but the pattern handling is at a low level:

1. No access to `picomatch` settings.
1. Works quickly only with simple patterns.

So, right now we are only interested in this project from the side of a quick read of the directory tree.