### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ The object has the following fields:
 
 * name (`string`) — the last part of the path (basename)
 * path (`string`) — full path relative to the pattern base directory
-* dirent ([`fs.Dirent`][node_js_fs_class_fs_dirent]) — instance of `fs.Direct`
+* dirent ([`fs.Dirent`][node_js_fs_class_fs_dirent]) — instance of `fs.Dirent`
 
 > :book: An object is an internal representation of entry, so getting it does not affect performance.
 


### PR DESCRIPTION
### What is the purpose of this pull request?
There's a little typo in the readme, which this fixes

### What changes did you make? (Give an overview)
Changed `fs.Direct` to `fs.Dirent`
