### PR TITLE
refactor: update glob-parent@6

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@nodelib/fs.stat": "^2.0.2",
     "@nodelib/fs.walk": "^1.2.3",
-    "glob-parent": "^5.1.2",
+    "glob-parent": "^6.0.1",
     "merge2": "^1.3.0",
     "micromatch": "^4.0.4"
   },


### PR DESCRIPTION
### What is the purpose of this pull request?

Update glob-parent to fix a reported vulnerability

- http://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-35065
- https://github.com/gulpjs/glob-parent/pull/49

This is a major upgrade, it no longer supports Node v10 and there are other breaking change
- See update note here https://github.com/gulpjs/glob-parent/blob/main/CHANGELOG.md#-breaking-changes

I can see that there are no tests cases included in this package.

### What changes did you make? (Give an overview)

- upgrade glob-parent to the next major version that fixed a reported vulnerability
