### PR TITLE
fix: adjust inefficient regular expression

### DIFF
--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -112,6 +112,7 @@ describe('Utils → Pattern', () => {
 
 			it('should return false for unfinished regex character class', () => {
 				assert.ok(!util.isDynamicPattern('['));
+				assert.ok(!util.isDynamicPattern('['.repeat(999999)));
 				assert.ok(!util.isDynamicPattern('[abc'));
 			});
 

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -9,7 +9,7 @@ const GLOBSTAR = '**';
 const ESCAPE_SYMBOL = '\\';
 
 const COMMON_GLOB_SYMBOLS_RE = /[*?]|^!/;
-const REGEX_CHARACTER_CLASS_SYMBOLS_RE = /\[.*]/;
+const REGEX_CHARACTER_CLASS_SYMBOLS_RE = /\[[^[]*]/;
 const REGEX_GROUP_SYMBOLS_RE = /(?:^|[^!*+?@])\(.*\|.*\)/;
 const GLOB_EXTENSION_SYMBOLS_RE = /[!*+?@]\(.*\)/;
 const BRACE_EXPANSIONS_SYMBOLS_RE = /{.*(?:,|\.\.).*}/;


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix a potential performance cliff in pathological case.

### What changes did you make? (Give an overview)

 Matching large numbers of repetitions of `[` can take a minute or more in the
 current code. This change gets it back down into the milliseconds as
 expected.

Instead of matching "open bracket followed by whatever and then a close bracket", this change has the regexp ignore repeated open brackets to avoid polynomial backtracking.