### PR TITLE
fix: remove performance cliff for regex

### DIFF
--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -118,6 +118,8 @@ describe('Utils → Pattern', () => {
 
 			it('should return false for unfinished regex group', () => {
 				assert.ok(!util.isDynamicPattern('(a|b'));
+				assert.ok(!util.isDynamicPattern('('.repeat(999999) + 'a|b'));
+				assert.ok(!util.isDynamicPattern('(a' + '|'.repeat(999999) + 'b'));
 				assert.ok(!util.isDynamicPattern('abc/(a|b'));
 			});
 

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -10,7 +10,7 @@ const ESCAPE_SYMBOL = '\\';
 
 const COMMON_GLOB_SYMBOLS_RE = /[*?]|^!/;
 const REGEX_CHARACTER_CLASS_SYMBOLS_RE = /\[[^[]*]/;
-const REGEX_GROUP_SYMBOLS_RE = /(?:^|[^!*+?@])\(.*\|.*\)/;
+const REGEX_GROUP_SYMBOLS_RE = /(?:^|[^!*+?@])\([^(]*\|[^|]*\)/;
 const GLOB_EXTENSION_SYMBOLS_RE = /[!*+?@]\(.*\)/;
 const BRACE_EXPANSIONS_SYMBOLS_RE = /{.*(?:,|\.\.).*}/;
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes a regex-backtracking performance cliff for some pathological cases.

### What changes did you make? (Give an overview)

Replaced `.*` in two places with matching lists `[^(]` and `[^|]`. Wrote tests to confirm performance cliffs in current code and their elimination with this change.
