### PR TITLE
ISSUE-345: fix invalid regular expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://mrmlnc.com"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.6.0"
   },
   "main": "out/index.js",
   "typings": "out/index.d.ts",

--- a/src/managers/patterns.ts
+++ b/src/managers/patterns.ts
@@ -1,8 +1,9 @@
 /**
  * Matches a sequence of two or more consecutive slashes, excluding the first two slashes at the beginning of the string.
  * The latter is due to the presence of the device path at the beginning of the UNC path.
+ * @todo rewrite to negative lookbehind with the next major release.
  */
-const DOUBLE_SLASH_RE = /(?<!^)\/{2,}/g;
+const DOUBLE_SLASH_RE = /(?!^)\/{2,}/g;
 
 export function transform(patterns: string[]): string[] {
 	return patterns.map((pattern) => removeDuplicateSlashes(pattern));


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix addressed to #345.

### What changes did you make? (Give an overview)

1. Require node.js 8.6.0. The `micromatch` package works only with node.js 8.6+. This is not a major change, since this version was previously required implicitly.
1. Fix regression from the issue.