### PR TITLE
Remove `fast-glob` devDependency on itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint": "^6.5.1",
     "eslint-config-mrmlnc": "^1.1.0",
     "execa": "^2.0.4",
-    "fast-glob": "^3.0.4",
     "fdir": "^5.1.0",
     "glob": "^7.1.4",
     "is-ci": "^2.0.0",


### PR DESCRIPTION
I think this package doesn't need to have devDependency on itself via line:
```
    "fast-glob": "^3.0.4",
```

### What is the purpose of this pull request?
Remove redundant dependency

### What changes did you make? (Give an overview)
Removed redundant devDependency
```
    "fast-glob": "^3.0.4",
```