### PR TITLE
ISSUE-351: Bash style brace expansions stops working after upgrade to 3.2.8

### DIFF
--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -79,6 +79,7 @@ describe('Utils → Pattern', () => {
 
 			it('should return true for patterns that include brace expansions symbols', () => {
 				assert.ok(util.isDynamicPattern('{,}'));
+				assert.ok(util.isDynamicPattern('abc/{a.txt,}'));
 				assert.ok(util.isDynamicPattern('{a,}'));
 				assert.ok(util.isDynamicPattern('{,b}'));
 				assert.ok(util.isDynamicPattern('{a,b}'));
@@ -88,6 +89,7 @@ describe('Utils → Pattern', () => {
 				// The second braces pass
 				assert.ok(util.isDynamicPattern('{a,b,{c,d}'));
 				assert.ok(util.isDynamicPattern('{1..3}'));
+				assert.ok(util.isDynamicPattern('abc/{1..3}'));
 				assert.ok(util.isDynamicPattern('{2..10..2}'));
 			});
 
@@ -141,6 +143,7 @@ describe('Utils → Pattern', () => {
 				assert.ok(!util.isDynamicPattern('{'));
 				assert.ok(!util.isDynamicPattern('{'.repeat(999999)));
 				assert.ok(!util.isDynamicPattern('{a'));
+				assert.ok(!util.isDynamicPattern('{a}'));
 				assert.ok(!util.isDynamicPattern('{,'));
 				assert.ok(!util.isDynamicPattern('{a,'));
 				assert.ok(!util.isDynamicPattern('{a,b'));

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -12,7 +12,7 @@ const COMMON_GLOB_SYMBOLS_RE = /[*?]|^!/;
 const REGEX_CHARACTER_CLASS_SYMBOLS_RE = /\[[^[]*]/;
 const REGEX_GROUP_SYMBOLS_RE = /(?:^|[^!*+?@])\([^(]*\|[^|]*\)/;
 const GLOB_EXTENSION_SYMBOLS_RE = /[!*+?@]\([^(]*\)/;
-const BRACE_EXPANSIONS_SYMBOLS_RE = /{[^,.{]*(?:,|\.\.)[^{]*}/;
+const BRACE_EXPANSION_SEPARATORS_RE = /,|\.\./;
 
 type PatternTypeOptions = {
 	braceExpansion?: boolean;
@@ -50,11 +50,29 @@ export function isDynamicPattern(pattern: Pattern, options: PatternTypeOptions =
 		return true;
 	}
 
-	if (options.braceExpansion !== false && BRACE_EXPANSIONS_SYMBOLS_RE.test(pattern)) {
+	if (options.braceExpansion !== false && hasBraceExpansion(pattern)) {
 		return true;
 	}
 
 	return false;
+}
+
+function hasBraceExpansion(pattern: string): boolean {
+	const openingBraceIndex = pattern.indexOf('{');
+
+	if (openingBraceIndex === -1) {
+		return false;
+	}
+
+	const closingBraceIndex = pattern.indexOf('}', openingBraceIndex + 1);
+
+	if (closingBraceIndex === -1) {
+		return false;
+	}
+
+	const braceContent = pattern.slice(openingBraceIndex, closingBraceIndex);
+
+	return BRACE_EXPANSION_SEPARATORS_RE.test(braceContent);
 }
 
 export function convertToPositivePattern(pattern: Pattern): Pattern {


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a final fix for #351 based on the first regular expression ([click](https://github.com/mrmlnc/fast-glob/blob/eda8195a92e789e9579eb36cfdb7a7639ba3fd8d/src/utils/pattern.ts#L15)).

### What changes did you make? (Give an overview)

> Some people, when confronted with a problem, think
> “I know, I'll use regular expressions.”   Now they have two problems.

So, аfter correcting the polynomial explosion ([1](https://github.com/mrmlnc/fast-glob/commit/5669faba60f9e1bfc10542231d9c7d83fc122e65), [2](https://github.com/mrmlnc/fast-glob/commit/92a7fcb35ac031a7c20aa237c0678dfa1139ace8)), we had problems with detecting brace expansion.

I couldn't write a valid regular expression (taking into account the current versions of platform) that would work with the pattern from issue (`abc/{a.txt,b.txt}`), so I rewrote it to a regular function. This function has a more generalized view and should work with any patterns.

It seems to me that the current solution is easier to understand and support.