### PR TITLE
test: add spec for negative groups

### DIFF
--- a/src/tests/smoke/regular.smoke.ts
+++ b/src/tests/smoke/regular.smoke.ts
@@ -504,3 +504,12 @@ smoke.suite('Smoke → Regular (relative & ignore)', [
 	{ pattern: '../{first,second}', cwd: 'fixtures/first', ignore: '../first/**' },
 	{ pattern: '../{first,second}', cwd: 'fixtures/first', ignore: '**/first/**' }
 ]);
+
+smoke.suite('Smoke -> Regular (negative group)', [
+	{
+		pattern: '**/!(*.md)',
+		cwd: 'fixtures/first',
+		broken: true,
+		issue: 357
+	}
+])


### PR DESCRIPTION
### What is the purpose of this pull request?
Add test for bug introduced in 3.2.8: See #357

### What changes did you make? (Give an overview)
Added failing test for negative groups
