### PR TITLE
perf: use fs.walk instead of fs.walkStream for async provider

### DIFF
--- a/src/readers/async.spec.ts
+++ b/src/readers/async.spec.ts
@@ -1,0 +1,79 @@
+import * as assert from 'assert';
+
+import { PassThrough } from 'stream';
+import * as sinon from 'sinon';
+import * as fsWalk from '@nodelib/fs.walk';
+import Settings, { Options } from '../settings';
+import { ReaderOptions } from '../types';
+import * as tests from '../tests';
+import ReaderAsync from './async';
+import ReaderStream from './stream';
+
+type WalkSignature = typeof fsWalk.walk;
+
+class TestReader extends ReaderAsync {
+	protected _walkAsync: WalkSignature = sinon.stub() as unknown as WalkSignature;
+	protected _readerStream: ReaderStream = sinon.createStubInstance(ReaderStream) as unknown as ReaderStream;
+
+	constructor(options?: Options) {
+		super(new Settings(options));
+	}
+
+	public get walkAsync(): sinon.SinonStub {
+		return this._walkAsync as unknown as sinon.SinonStub;
+	}
+
+	public get readerStream(): sinon.SinonStubbedInstance<ReaderStream> {
+		return this._readerStream as unknown as sinon.SinonStubbedInstance<ReaderStream>;
+	}
+}
+
+function getReader(options?: Options): TestReader {
+	return new TestReader(options);
+}
+
+function getReaderOptions(options: Partial<ReaderOptions> = {}): ReaderOptions {
+	return { ...options } as unknown as ReaderOptions;
+}
+
+describe('Readers → ReaderAsync', () => {
+	describe('Constructor', () => {
+		it('should create instance of class', () => {
+			const reader = getReader();
+
+			assert.ok(reader instanceof TestReader);
+		});
+	});
+
+	describe('.dynamic', () => {
+		it('should call fs.walk method', async () => {
+			const reader = getReader();
+			const readerOptions = getReaderOptions();
+
+			reader.walkAsync.yields(null, []);
+
+			await reader.dynamic('root', readerOptions);
+
+			assert.ok(reader.walkAsync.called);
+		});
+	});
+
+	describe('.static', () => {
+		it('should call stream reader method', async () => {
+			const entry = tests.entry.builder().path('root/file.txt').build();
+
+			const reader = getReader();
+			const readerOptions = getReaderOptions();
+			const readerStream = new PassThrough({ objectMode: true });
+
+			readerStream.push(entry);
+			readerStream.push(null);
+
+			reader.readerStream.static.returns(readerStream);
+
+			await reader.static(['a.txt'], readerOptions);
+
+			assert.ok(reader.readerStream.static.called);
+		});
+	});
+});

--- a/src/readers/async.ts
+++ b/src/readers/async.ts
@@ -1,0 +1,34 @@
+import * as fsWalk from '@nodelib/fs.walk';
+import { Entry, ReaderOptions, Pattern } from '../types';
+import Reader from './reader';
+import ReaderStream from './stream';
+
+export default class ReaderAsync extends Reader<Promise<Entry[]>> {
+	protected _walkAsync: typeof fsWalk.walk = fsWalk.walk;
+	protected _readerStream: ReaderStream = new ReaderStream(this._settings);
+
+	public dynamic(root: string, options: ReaderOptions): Promise<Entry[]> {
+		return new Promise((resolve, reject) => {
+			this._walkAsync(root, options, (error, entries) => {
+				if (error === null) {
+					resolve(entries);
+				} else {
+					reject(error);
+				}
+			});
+		});
+	}
+
+	public async static(patterns: Pattern[], options: ReaderOptions): Promise<Entry[]> {
+		const entries: Entry[] = [];
+
+		const stream = this._readerStream.static(patterns, options);
+
+		// After #235, replace it with an asynchronous iterator.
+		return new Promise((resolve, reject) => {
+			stream.once('error', reject);
+			stream.on('data', (entry: Entry) => entries.push(entry));
+			stream.once('end', () => resolve(entries));
+		});
+	}
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

Improving the performance of the `fg('**')` method.

Something like ~20% for medium directories and trees. Practically nothing for large directories and trees (1 million and more).

```js
// *
===> Benchmark pattern "*" with 200 launches (regression, async)
===> Max stdev: 7 | Retries: 5 | Options: {}

Name                   Time, ms  Time stdev, %  Memory, MB  Memory stdev, %  Entries  Errors  Retries
---------------------  --------  -------------  ----------  ---------------  -------  ------  -------
fast-glob-current.js   6.970     0.402          4.388       0.014            5        0       1
fast-glob-previous.js  8.571     0.430          4.531       0.015            5        0       1

// **
===> Benchmark pattern "**" with 200 launches (regression, async)
===> Max stdev: 7 | Retries: 5 | Options: {}

Name                   Time, ms  Time stdev, %  Memory, MB  Memory stdev, %  Entries  Errors  Retries
---------------------  --------  -------------  ----------  ---------------  -------  ------  -------
fast-glob-current.js   89.665    3.884          9.649       0.380            11882    0       1
fast-glob-previous.js  112.966   5.370          7.760       0.112            11882    0       1
```

### What changes did you make? (Give an overview)

Instead of using the `ReaderStream` reader, now we use the `ReaderAsync` reader. This avoids the overhead of stream processing.

But we still use `ReaderStream` for `static` method.