### PR TITLE
Update glob-parent to 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@nodelib/fs.stat": "^2.0.2",
     "@nodelib/fs.walk": "^1.2.3",
-    "glob-parent": "^5.1.2",
+    "glob-parent": "^6.0.1",
     "merge2": "^1.3.0",
     "micromatch": "^4.0.4"
   },


### PR DESCRIPTION
### What is the purpose of this pull request?

Solving CVE-2021-35065 (https://github.com/advisories/GHSA-cj88-88mr-972w)

### What changes did you make? (Give an overview)

Updating `glob-parent` to `6.0.1`
