### PR TITLE
streams: Rework stream merging to use ordered-read-streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/glob": "^7.1.1",
     "@types/glob-parent": "^5.1.0",
     "@types/is-ci": "^2.0.0",
-    "@types/merge2": "^1.1.4",
     "@types/micromatch": "^4.0.0",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^5.2.7",
@@ -60,7 +59,7 @@
     "@nodelib/fs.stat": "^2.0.2",
     "@nodelib/fs.walk": "^1.2.3",
     "glob-parent": "^5.1.2",
-    "merge2": "^1.3.0",
+    "ordered-read-streams": "^2.0.0",
     "micromatch": "^4.0.4"
   },
   "scripts": {

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,20 +1,8 @@
 import { Readable } from 'stream';
 
-import * as merge2 from 'merge2';
+// @ts-expect-error
+import * as ordered from 'ordered-read-streams';
 
-export function merge(streams: Readable[]): NodeJS.ReadableStream {
-	const mergedStream = merge2(streams);
-
-	streams.forEach((stream) => {
-		stream.once('error', (error) => mergedStream.emit('error', error));
-	});
-
-	mergedStream.once('close', () => propagateCloseEventToSources(streams));
-	mergedStream.once('end', () => propagateCloseEventToSources(streams));
-
-	return mergedStream;
-}
-
-function propagateCloseEventToSources(streams: Readable[]): void {
-	streams.forEach((stream) => stream.emit('close'));
+export function merge(streams: Readable[]): Readable {
+	return ordered(streams);
 }


### PR DESCRIPTION
streams: Rework stream tests to be more stream compliant

### What is the purpose of this pull request?

I'm investigating fast-glob for usage in gulp via glob-stream and I noticed that you were using merge2, which does some really unconventional things. This swaps the dependency for `ordered-read-streams` which has recently been overhauled to be stream/streamx-compliant.

### What changes did you make? (Give an overview)

I swapped the merge2 dependency for ordered-read-streams and removed a lot of the event rebinding that was done for merge2. I then updated the tests to show better stream compliance—using things like `destroy` and Readables that provide data instead of trying to propagate events and rely on specific listeners being bound.
