### PR TITLE
settings: Add uniqueBy function

### DIFF
--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -3,7 +3,7 @@ import { Entry, EntryFilterFunction, MicromatchOptions, Pattern, PatternRe } fro
 import * as utils from '../../utils';
 
 export default class EntryFilter {
-	public readonly index: Map<string, undefined> = new Map();
+	public readonly index: Map<unknown, undefined> = new Map();
 
 	constructor(private readonly _settings: Settings, private readonly _micromatchOptions: MicromatchOptions) {}
 
@@ -40,7 +40,7 @@ export default class EntryFilter {
 	}
 
 	private _isDuplicateEntry(entry: Entry): boolean {
-		return this.index.has(entry.path);
+		return this.index.has(this._settings.uniqueBy(entry));
 	}
 
 	private _createIndexRecord(entry: Entry): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 
-import { FileSystemAdapter, Pattern } from './types';
+import { Entry, FileSystemAdapter, Pattern } from './types';
 
 /**
  * The `os.cpus` method can return zero. We expect the number of cores to be greater than zero.
@@ -152,6 +152,12 @@ export type Options = {
 	 * @default true
 	 */
 	unique?: boolean;
+	/**
+	 * Overrides the uniqueness value when `unique` is set to `true`.
+	 *
+	 * @default (entry) => entry.path
+	 */
+	uniqueBy?: (entry: Entry) => unknown;
 };
 
 export default class Settings {
@@ -176,6 +182,7 @@ export default class Settings {
 	public readonly suppressErrors: boolean = this._getValue(this._options.suppressErrors, false);
 	public readonly throwErrorOnBrokenSymbolicLink: boolean = this._getValue(this._options.throwErrorOnBrokenSymbolicLink, false);
 	public readonly unique: boolean = this._getValue(this._options.unique, true);
+	public readonly uniqueBy: (entry: Entry) => unknown = this._getValue(this._options.uniqueBy, (entry: Entry) => entry.path);
 
 	constructor(private readonly _options: Options = {}) {
 		if (this.onlyDirectories) {


### PR DESCRIPTION
### What is the purpose of this pull request?

I've been investigating fast-glob for usage in gulp via glob-stream and I noticed you had a `unique` setting, but not a way to configure the uniqueness value. We provide a `uniqueBy` configuration that we passed into a `unique-stream` to deduplicate values. However, if fast-glob provides that functionality, we can drop `unique-stream` and `pumpify` dependencies which would be a huge performance win!

### What changes did you make? (Give an overview)

I added a `uniqueBy` option that is used to pluck the property to use for duplicate entries. This defaults to plucking `entry.path` by default.
