### PR TITLE
Make async available in named export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ namespace FastGlob {
 	export type Pattern = PatternInternal;
 	export type FileSystemAdapter = FileSystemAdapterInternal;
 
+	export const async = FastGlob;
+
 	export function sync(source: PatternInternal | PatternInternal[], options: OptionsInternal & EntryObjectPredicate): EntryInternal[];
 	export function sync(source: PatternInternal | PatternInternal[], options?: OptionsInternal): string[];
 	export function sync(source: PatternInternal | PatternInternal[], options?: OptionsInternal): EntryItem[] {


### PR DESCRIPTION
### What is the purpose of this pull request?

For people using ESM projects, assigning to `export = FastGlob` makes default import impossible without TSC interop interceding for it.
Ideally, the export signature should change, but that would be a breaking change.


### What changes did you make? (Give an overview)
So for now, and to make the export signature more consistent anyway, I'm proposing just adding the async implementation to the named exports, which happens to also be best-practice for ESM.
