### PR TITLE
ISSUE-240: Method to convert path to pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This package provides methods for traversing the file system and returning pathn
   * [Helpers](#helpers)
     * [generateTasks](#generatetaskspatterns-options)
     * [isDynamicPattern](#isdynamicpatternpattern-options)
-    * [escapePath](#escapepathpattern)
+    * [escapePath](#escapepathpath)
 * [Options](#options-3)
   * [Common](#common)
     * [concurrency](#concurrency)
@@ -268,21 +268,32 @@ Any correct pattern.
 
 See [Options](#options-3) section.
 
-#### `escapePath(pattern)`
+#### `escapePath(path)`
 
-Returns a path with escaped special characters (`*?|(){}[]`, `!` at the beginning of line, `@+!` before the opening parenthesis).
+Returns the path with escaped special characters depending on the platform.
+
+* Posix:
+  * `*?|(){}[]`;
+  * `!` at the beginning of line;
+  * `@+!` before the opening parenthesis;
+  * `\\` before non-special characters;
+* Windows:
+  * `(){}`
+  * `!` at the beginning of line;
+  * `@+!` before the opening parenthesis;
+  * Characters like `*?|[]` cannot be used in the path ([windows_naming_conventions][windows_naming_conventions]), so they will not be escaped;
 
 ```js
-fg.escapePath('!abc'); // \\!abc
-fg.escapePath('C:/Program Files (x86)'); // C:/Program Files \\(x86\\)
+fg.escapePath('!abc');
+// \\!abc
+fg.escapePath('[OpenSource] mrmlnc – fast-glob (Deluxe Edition) 2014') + '/*.flac'
+// \\[OpenSource\\] mrmlnc – fast-glob \\(Deluxe Edition\\) 2014/*.flac
+
+fg.posix.escapePath('C:\\Program Files (x86)\\**\\*');
+// C:\\\\Program Files \\(x86\\)\\*\\*\\*
+fg.win32.escapePath('C:\\Program Files (x86)\\**\\*');
+// Windows: C:\\Program Files \\(x86\\)\\**\\*
 ```
-
-##### pattern
-
-* Required: `true`
-* Type: `string`
-
-Any string, for example, a path to a file.
 
 ## Options
 
@@ -815,3 +826,4 @@ This software is released under the terms of the MIT license.
 [zotac_bi323]: https://www.zotac.com/ee/product/mini_pcs/zbox-bi323
 [nodejs_thread_pool]: https://nodejs.org/en/docs/guides/dont-block-the-event-loop
 [libuv_thread_pool]: http://docs.libuv.org/en/v1.x/threadpool.html
+[windows_naming_conventions]: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -239,7 +239,20 @@ describe('Package', () => {
 		});
 	});
 
-	describe('.posix', () => {
+	describe('.convertPathToPattern', () => {
+		it('should return a pattern', () => {
+			// In posix system \\ is a escaping character and it will be escaped before non-special characters.
+			const posix = 'C:\\\\Program Files \\(x86\\)\\*\\*\\*';
+			const windows = 'C:/Program Files \\(x86\\)/**/*';
+			const expected = tests.platform.isWindows() ? windows : posix;
+
+			const actual = fg.convertPathToPattern('C:\\Program Files (x86)\\**\\*');
+
+			assert.strictEqual(actual, expected);
+		});
+	});
+
+	describe('posix', () => {
 		describe('.escapePath', () => {
 			it('should return escaped path', () => {
 				const expected = '/directory/\\*\\*/\\*';
@@ -249,14 +262,34 @@ describe('Package', () => {
 				assert.strictEqual(actual, expected);
 			});
 		});
+
+		describe('.convertPathToPattern', () => {
+			it('should return a pattern', () => {
+				const expected = 'a\\*.txt';
+
+				const actual = fg.posix.convertPathToPattern('a\\*.txt');
+
+				assert.strictEqual(actual, expected);
+			});
+		});
 	});
 
-	describe('.win32', () => {
+	describe('win32', () => {
 		describe('.escapePath', () => {
 			it('should return escaped path', () => {
 				const expected = 'C:\\Program Files \\(x86\\)\\**\\*';
 
 				const actual = fg.win32.escapePath('C:\\Program Files (x86)\\**\\*');
+
+				assert.strictEqual(actual, expected);
+			});
+		});
+
+		describe('.convertPathToPattern', () => {
+			it('should return a pattern', () => {
+				const expected = 'C:/Program Files \\(x86\\)/**/*';
+
+				const actual = fg.win32.convertPathToPattern('C:\\Program Files (x86)\\**\\*');
 
 				assert.strictEqual(actual, expected);
 			});

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -238,4 +238,28 @@ describe('Package', () => {
 			assert.strictEqual(actual, expected);
 		});
 	});
+
+	describe('.posix', () => {
+		describe('.escapePath', () => {
+			it('should return escaped path', () => {
+				const expected = '/directory/\\*\\*/\\*';
+
+				const actual = fg.posix.escapePath('/directory/*\\*/*');
+
+				assert.strictEqual(actual, expected);
+			});
+		});
+	});
+
+	describe('.win32', () => {
+		describe('.escapePath', () => {
+			it('should return escaped path', () => {
+				const expected = 'C:\\Program Files \\(x86\\)\\**\\*';
+
+				const actual = fg.win32.escapePath('C:\\Program Files (x86)\\**\\*');
+
+				assert.strictEqual(actual, expected);
+			});
+		});
+	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,10 +78,26 @@ namespace FastGlob {
 		return utils.pattern.isDynamicPattern(source, settings);
 	}
 
-	export function escapePath(source: PatternInternal): PatternInternal {
+	export function escapePath(source: string): PatternInternal {
 		assertPatternsInput(source);
 
 		return utils.path.escape(source);
+	}
+
+	export namespace posix {
+		export function escapePath(source: string): PatternInternal {
+			assertPatternsInput(source);
+
+			return utils.path.escapePosixPath(source);
+		}
+	}
+
+	export namespace win32 {
+		export function escapePath(source: string): PatternInternal {
+			assertPatternsInput(source);
+
+			return utils.path.escapeWindowsPath(source);
+		}
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,11 +84,23 @@ namespace FastGlob {
 		return utils.path.escape(source);
 	}
 
+	export function convertPathToPattern(source: string): PatternInternal {
+		assertPatternsInput(source);
+
+		return utils.path.convertPathToPattern(source);
+	}
+
 	export namespace posix {
 		export function escapePath(source: string): PatternInternal {
 			assertPatternsInput(source);
 
 			return utils.path.escapePosixPath(source);
+		}
+
+		export function convertPathToPattern(source: string): PatternInternal {
+			assertPatternsInput(source);
+
+			return utils.path.convertPosixPathToPattern(source);
 		}
 	}
 
@@ -97,6 +109,12 @@ namespace FastGlob {
 			assertPatternsInput(source);
 
 			return utils.path.escapeWindowsPath(source);
+		}
+
+		export function convertPathToPattern(source: string): PatternInternal {
+			assertPatternsInput(source);
+
+			return utils.path.convertWindowsPathToPattern(source);
 		}
 	}
 }

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -24,37 +24,6 @@ describe('Utils → Path', () => {
 		});
 	});
 
-	describe('.escapePattern', () => {
-		it('should return pattern with escaped glob symbols', () => {
-			assert.strictEqual(util.escape('!abc'), '\\!abc');
-			assert.strictEqual(util.escape('*'), '\\*');
-			assert.strictEqual(util.escape('?'), '\\?');
-			assert.strictEqual(util.escape('()'), '\\(\\)');
-			assert.strictEqual(util.escape('{}'), '\\{\\}');
-			assert.strictEqual(util.escape('[]'), '\\[\\]');
-			assert.strictEqual(util.escape('@('), '\\@\\(');
-			assert.strictEqual(util.escape('!('), '\\!\\(');
-			assert.strictEqual(util.escape('*('), '\\*\\(');
-			assert.strictEqual(util.escape('?('), '\\?\\(');
-			assert.strictEqual(util.escape('+('), '\\+\\(');
-		});
-
-		it('should return pattern without additional escape characters', () => {
-			assert.strictEqual(util.escape('\\!abc'), '\\!abc');
-			assert.strictEqual(util.escape('\\*'), '\\*');
-			assert.strictEqual(util.escape('\\!\\('), '\\!\\(');
-		});
-
-		it('should return pattern without escape characters', () => {
-			assert.strictEqual(util.escape('abc!'), 'abc!');
-			assert.strictEqual(util.escape('abc/!abc'), 'abc/!abc');
-			assert.strictEqual(util.escape('+abc'), '+abc');
-			assert.strictEqual(util.escape('abc+'), 'abc+');
-			assert.strictEqual(util.escape('@abc'), '@abc');
-			assert.strictEqual(util.escape('abc@'), 'abc@');
-		});
-	});
-
 	describe('.removeLeadingDotCharacters', () => {
 		it('should return path without changes', () => {
 			assert.strictEqual(util.removeLeadingDotSegment('../a/b'), '../a/b');
@@ -71,6 +40,51 @@ describe('Utils → Path', () => {
 		it('should return path without leading dit characters', () => {
 			assert.strictEqual(util.removeLeadingDotSegment('./a/b'), 'a/b');
 			assert.strictEqual(util.removeLeadingDotSegment('.\\a\\b'), 'a\\b');
+		});
+	});
+
+	describe('.escapePattern', () => {
+		it('should return pattern without additional escape characters', () => {
+			assert.strictEqual(util.escape('\\!abc'), '\\!abc');
+			assert.strictEqual(util.escape('\\*'), '\\*');
+			assert.strictEqual(util.escape('\\!\\('), '\\!\\(');
+		});
+
+		it('should return pattern without escape characters', () => {
+			assert.strictEqual(util.escape('abc!'), 'abc!');
+			assert.strictEqual(util.escape('abc/!abc'), 'abc/!abc');
+			assert.strictEqual(util.escape('+abc'), '+abc');
+			assert.strictEqual(util.escape('abc+'), 'abc+');
+			assert.strictEqual(util.escape('@abc'), '@abc');
+			assert.strictEqual(util.escape('abc@'), 'abc@');
+		});
+	});
+
+	describe('.escapePosixPattern', () => {
+		it('should return pattern with escaped glob symbols', () => {
+			assert.strictEqual(util.escapePosixPath('!abc'), '\\!abc');
+			assert.strictEqual(util.escapePosixPath('*'), '\\*');
+			assert.strictEqual(util.escapePosixPath('?'), '\\?');
+			assert.strictEqual(util.escapePosixPath('\\'), '\\\\');
+			assert.strictEqual(util.escapePosixPath('()'), '\\(\\)');
+			assert.strictEqual(util.escapePosixPath('{}'), '\\{\\}');
+			assert.strictEqual(util.escapePosixPath('[]'), '\\[\\]');
+			assert.strictEqual(util.escapePosixPath('@('), '\\@\\(');
+			assert.strictEqual(util.escapePosixPath('!('), '\\!\\(');
+			assert.strictEqual(util.escapePosixPath('*('), '\\*\\(');
+			assert.strictEqual(util.escapePosixPath('?('), '\\?\\(');
+			assert.strictEqual(util.escapePosixPath('+('), '\\+\\(');
+		});
+	});
+
+	describe('.escapeWindowsPattern', () => {
+		it('should return pattern with escaped glob symbols', () => {
+			assert.strictEqual(util.escapeWindowsPath('!abc'), '\\!abc');
+			assert.strictEqual(util.escapeWindowsPath('()'), '\\(\\)');
+			assert.strictEqual(util.escapeWindowsPath('{}'), '\\{\\}');
+			assert.strictEqual(util.escapeWindowsPath('@('), '\\@\\(');
+			assert.strictEqual(util.escapeWindowsPath('!('), '\\!\\(');
+			assert.strictEqual(util.escapeWindowsPath('+('), '\\+\\(');
 		});
 	});
 });

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -24,26 +24,7 @@ describe('Utils → Path', () => {
 		});
 	});
 
-	describe('.removeLeadingDotCharacters', () => {
-		it('should return path without changes', () => {
-			assert.strictEqual(util.removeLeadingDotSegment('../a/b'), '../a/b');
-			assert.strictEqual(util.removeLeadingDotSegment('~/a/b'), '~/a/b');
-			assert.strictEqual(util.removeLeadingDotSegment('/a/b'), '/a/b');
-			assert.strictEqual(util.removeLeadingDotSegment('a/b'), 'a/b');
-
-			assert.strictEqual(util.removeLeadingDotSegment('..\\a\\b'), '..\\a\\b');
-			assert.strictEqual(util.removeLeadingDotSegment('~\\a\\b'), '~\\a\\b');
-			assert.strictEqual(util.removeLeadingDotSegment('\\a\\b'), '\\a\\b');
-			assert.strictEqual(util.removeLeadingDotSegment('a\\b'), 'a\\b');
-		});
-
-		it('should return path without leading dit characters', () => {
-			assert.strictEqual(util.removeLeadingDotSegment('./a/b'), 'a/b');
-			assert.strictEqual(util.removeLeadingDotSegment('.\\a\\b'), 'a\\b');
-		});
-	});
-
-	describe('.escapePattern', () => {
+	describe('.escape', () => {
 		it('should return pattern without additional escape characters', () => {
 			assert.strictEqual(util.escape('\\!abc'), '\\!abc');
 			assert.strictEqual(util.escape('\\*'), '\\*');
@@ -85,6 +66,105 @@ describe('Utils → Path', () => {
 			assert.strictEqual(util.escapeWindowsPath('@('), '\\@\\(');
 			assert.strictEqual(util.escapeWindowsPath('!('), '\\!\\(');
 			assert.strictEqual(util.escapeWindowsPath('+('), '\\+\\(');
+		});
+	});
+
+	describe('.removeLeadingDotCharacters', () => {
+		it('should return path without changes', () => {
+			assert.strictEqual(util.removeLeadingDotSegment('../a/b'), '../a/b');
+			assert.strictEqual(util.removeLeadingDotSegment('~/a/b'), '~/a/b');
+			assert.strictEqual(util.removeLeadingDotSegment('/a/b'), '/a/b');
+			assert.strictEqual(util.removeLeadingDotSegment('a/b'), 'a/b');
+
+			assert.strictEqual(util.removeLeadingDotSegment('..\\a\\b'), '..\\a\\b');
+			assert.strictEqual(util.removeLeadingDotSegment('~\\a\\b'), '~\\a\\b');
+			assert.strictEqual(util.removeLeadingDotSegment('\\a\\b'), '\\a\\b');
+			assert.strictEqual(util.removeLeadingDotSegment('a\\b'), 'a\\b');
+		});
+
+		it('should return path without leading dit characters', () => {
+			assert.strictEqual(util.removeLeadingDotSegment('./a/b'), 'a/b');
+			assert.strictEqual(util.removeLeadingDotSegment('.\\a\\b'), 'a\\b');
+		});
+	});
+
+	describe('.convertPathToPattern', () => {
+		it('should return a pattern', () => {
+			assert.strictEqual(util.convertPathToPattern('.{directory}'), '.\\{directory\\}');
+		});
+	});
+
+	describe('.convertPosixPathToPattern', () => {
+		it('should escape special characters', () => {
+			assert.strictEqual(util.convertPosixPathToPattern('./**\\*'), './\\*\\*\\*');
+		});
+	});
+
+	describe('.convertWindowsPathToPattern', () => {
+		it('should escape special characters', () => {
+			assert.strictEqual(util.convertPosixPathToPattern('.{directory}'), '.\\{directory\\}');
+		});
+
+		it('should do nothing with escaped glob symbols', () => {
+			assert.strictEqual(util.convertWindowsPathToPattern('\\!\\'), '\\!/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\+\\'), '\\+/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\@\\'), '\\@/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\(\\'), '\\(/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\)\\'), '\\)/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\{\\'), '\\{/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\}\\'), '\\}/');
+
+			assert.strictEqual(util.convertWindowsPathToPattern('.\\*'), './*');
+			assert.strictEqual(util.convertWindowsPathToPattern('.\\**'), './**');
+			assert.strictEqual(util.convertWindowsPathToPattern('.\\**\\*'), './**/*');
+
+			assert.strictEqual(util.convertWindowsPathToPattern('a\\{b,c\\d,{b,c}}'), 'a\\{b,c/d,\\{b,c\\}\\}');
+		});
+
+		it('should convert slashes', () => {
+			assert.strictEqual(util.convertWindowsPathToPattern('/'), '/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\'), '/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\\\'), '//');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\/'), '//');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\/\\'), '///');
+		});
+
+		it('should convert relative paths', () => {
+			assert.strictEqual(util.convertWindowsPathToPattern('file.txt'), 'file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('./file.txt'), './file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('.\\file.txt'), './file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('../file.txt'), '../file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('..\\file.txt'), '../file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('.\\file.txt'), './file.txt');
+		});
+
+		it('should convert absolute paths', () => {
+			assert.strictEqual(util.convertWindowsPathToPattern('/.file.txt'), '/.file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('/root/.file.txt'), '/root/.file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\.file.txt'), '/.file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\root\\.file.txt'), '/root/.file.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\root/.file.txt'), '/root/.file.txt');
+		});
+
+		it('should convert traditional DOS paths', () => {
+			assert.strictEqual(util.convertWindowsPathToPattern('D:ShipId.txt'), 'D:ShipId.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('D:/ShipId.txt'), 'D:/ShipId.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('D://ShipId.txt'), 'D://ShipId.txt');
+
+			assert.strictEqual(util.convertWindowsPathToPattern('D:\\ShipId.txt'), 'D:/ShipId.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('D:\\\\ShipId.txt'), 'D://ShipId.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('D:\\/ShipId.txt'), 'D://ShipId.txt');
+		});
+
+		it('should convert UNC paths', () => {
+			assert.strictEqual(util.convertWindowsPathToPattern('\\\\system07\\'), '//system07/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\\\system07\\c$\\'), '//system07/c$/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\\\Server02\\Share\\Foo.txt'), '//Server02/Share/Foo.txt');
+
+			assert.strictEqual(util.convertWindowsPathToPattern('\\\\127.0.0.1\\c$\\File.txt'), '//127.0.0.1/c$/File.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\\\.\\c:\\File.txt'), '//./c:/File.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\\\?\\c:\\File.txt'), '//?/c:/File.txt');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\\\.\\UNC\\LOCALHOST\\c$\\File.txt'), '//./UNC/LOCALHOST/c$/File.txt');
 		});
 	});
 });


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix #240.

The main purpose is to allow users to stop processing Windows paths in each location where this package is used, using third-party packages.

The story about automatic pattern conversion is out of the issue now, as it is a separate big layer of problems.

### What changes did you make? (Give an overview)

1. The `.escapePath` method now escapes a different set of special characters depending on the platform. Two methods have also been added: `.escapePosixPath`, `.escapeWindowsPath`.
  1.1. Added support for escaping an escape character (`\\`) when it is not followed by a special character.
  1.2. On Windows, the following characters `*?|[]` will no longer be escaped. Because it is not possible to use these characters in a path in DOS.
2. Added the `.convertPathToPattern` method, which allows you to safely convert DOS paths and UNC paths into patterns.  Two methods have also been added: `.convertPosixPathToPattern`, `.convertWindowsPathToPattern`.
  2.1. This allows Windows paths to be passed as patterns after they have been converted. For example, `fg.convertPathToPattern('\\\\?\\c:\\Program Files (x86)') + '/**'` or `fg.convertPathToPattern('C://Program Files (x86)') + '/**'`.
  2.2. Remove dependencies like `normalize-path` and `slash`, which we previously suggested in the documentation.

More details in the documentation.