### PR TITLE
ISSUE-312: correctly handle patterns without slashes when the `baseNameMatch` option is enabled

### DIFF
--- a/__snapshots__/base-name-match.e2e.js
+++ b/__snapshots__/base-name-match.e2e.js
@@ -1,38 +1,59 @@
-exports['Options MatchBase {"pattern":"*.md","options":{"cwd":"fixtures","baseNameMatch":true}} (sync) 1'] = [
-  ".directory/file.md",
+exports['Options MatchBase {"pattern":"file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (sync) 1'] = [
   "file.md",
   "first/file.md",
   "first/nested/directory/file.md",
   "first/nested/file.md",
   "second/file.md",
   "second/nested/directory/file.md",
-  "second/nested/file.md",
-  "third/library/a/book.md",
-  "third/library/b/book.md"
+  "second/nested/file.md"
 ]
 
-exports['Options MatchBase {"pattern":"*.md","options":{"cwd":"fixtures","baseNameMatch":true}} (async) 1'] = [
-  ".directory/file.md",
+exports['Options MatchBase {"pattern":"file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (async) 1'] = [
   "file.md",
   "first/file.md",
   "first/nested/directory/file.md",
   "first/nested/file.md",
   "second/file.md",
   "second/nested/directory/file.md",
-  "second/nested/file.md",
-  "third/library/a/book.md",
-  "third/library/b/book.md"
+  "second/nested/file.md"
 ]
 
-exports['Options MatchBase {"pattern":"*.md","options":{"cwd":"fixtures","baseNameMatch":true}} (stream) 1'] = [
-  ".directory/file.md",
+exports['Options MatchBase {"pattern":"file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (stream) 1'] = [
   "file.md",
   "first/file.md",
   "first/nested/directory/file.md",
   "first/nested/file.md",
   "second/file.md",
   "second/nested/directory/file.md",
-  "second/nested/file.md",
-  "third/library/a/book.md",
-  "third/library/b/book.md"
+  "second/nested/file.md"
+]
+
+exports['Options MatchBase {"pattern":"first/*/file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (sync) 1'] = [
+  "first/nested/file.md"
+]
+
+exports['Options MatchBase {"pattern":"first/*/file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (async) 1'] = [
+  "first/nested/file.md"
+]
+
+exports['Options MatchBase {"pattern":"first/*/file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (stream) 1'] = [
+  "first/nested/file.md"
+]
+
+exports['Options MatchBase {"pattern":"first/**/file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (sync) 1'] = [
+  "first/file.md",
+  "first/nested/directory/file.md",
+  "first/nested/file.md"
+]
+
+exports['Options MatchBase {"pattern":"first/**/file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (async) 1'] = [
+  "first/file.md",
+  "first/nested/directory/file.md",
+  "first/nested/file.md"
+]
+
+exports['Options MatchBase {"pattern":"first/**/file.md","options":{"cwd":"fixtures","baseNameMatch":true}} (stream) 1'] = [
+  "first/file.md",
+  "first/nested/directory/file.md",
+  "first/nested/file.md"
 ]

--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -69,6 +69,30 @@ describe('Managers → Task', () => {
 
 			assert.deepStrictEqual(actual, expected);
 		});
+
+		it('should do not process patterns when the `baseNameMatch` option is enabled and the pattern has a slash', () => {
+			const settings = new Settings({ baseNameMatch: true });
+
+			const expected = [
+				tests.task.builder().base('root').positive('root/*/file.txt').build()
+			];
+
+			const actual = manager.generate(['root/*/file.txt'], settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should add glob star to patterns when the `baseNameMatch` option is enabled and the pattern does not have a slash', () => {
+			const settings = new Settings({ baseNameMatch: true });
+
+			const expected = [
+				tests.task.builder().base('.').positive('**/file.txt').build()
+			];
+
+			const actual = manager.generate(['file.txt'], settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
 	});
 
 	describe('.convertPatternsToTasks', () => {

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -41,6 +41,18 @@ function processPatterns(input: Pattern[], settings: Settings): Pattern[] {
 	}
 
 	/**
+	 * If the `baseNameMatch` option is enabled, we must add globstar to patterns, so that they can be used
+	 * at any nesting level.
+	 *
+	 * We do this here, because otherwise we have to complicate the filtering logic. For example, we need to change
+	 * the pattern in the filter before creating a regular expression. There is no need to change the patterns
+	 * in the application. Only on the input.
+	 */
+	if (settings.baseNameMatch) {
+		patterns = patterns.map((pattern) => pattern.includes('/') ? pattern : `**/${pattern}`);
+	}
+
+	/**
 	 * This method also removes duplicate slashes that may have been in the pattern or formed as a result of expansion.
 	 */
 	return patterns.map((pattern) => utils.pattern.removeDuplicateSlashes(pattern));

--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -180,14 +180,15 @@ describe('Providers → Filters → Entry', () => {
 		describe('options.baseNameMatch', () => {
 			it('should reject an entry', () => {
 				reject(FILE_ENTRY, {
-					positive: ['*'],
+					positive: ['file.txt'],
 					options: { baseNameMatch: false }
 				});
 			});
 
 			it('should accept an entry', () => {
 				accept(FILE_ENTRY, {
-					positive: ['*'],
+					// The task manager adds globstar for patterns without slash.
+					positive: ['**/file.txt'],
 					options: { baseNameMatch: true }
 				});
 			});

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -30,10 +30,9 @@ export default class EntryFilter {
 			return false;
 		}
 
-		const filepath = this._settings.baseNameMatch ? entry.name : entry.path;
 		const isDirectory = entry.dirent.isDirectory();
 
-		const isMatched = this._isMatchToPatterns(filepath, positiveRe, isDirectory) && !this._isMatchToPatterns(entry.path, negativeRe, isDirectory);
+		const isMatched = this._isMatchToPatterns(entry.path, positiveRe, isDirectory) && !this._isMatchToPatterns(entry.path, negativeRe, isDirectory);
 
 		if (this._settings.unique && isMatched) {
 			this._createIndexRecord(entry);

--- a/src/tests/e2e/options/base-name-match.e2e.ts
+++ b/src/tests/e2e/options/base-name-match.e2e.ts
@@ -3,7 +3,21 @@ import * as runner from '../runner';
 runner.suite('Options MatchBase', {
 	tests: [
 		{
-			pattern: '*.md',
+			pattern: 'file.md',
+			options: {
+				cwd: 'fixtures',
+				baseNameMatch: true
+			}
+		},
+		{
+			pattern: 'first/*/file.md',
+			options: {
+				cwd: 'fixtures',
+				baseNameMatch: true
+			}
+		},
+		{
+			pattern: 'first/**/file.md',
 			options: {
 				cwd: 'fixtures',
 				baseNameMatch: true


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for #312.

### What changes did you make? (Give an overview)
…
