### PR TITLE
fix: filter out empty patterns after their expansion

### DIFF
--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -422,6 +422,14 @@ describe('Utils → Pattern', () => {
 
 			assert.deepStrictEqual(actual, expected);
 		});
+
+		it('should filter an empty patterns after expansion', () => {
+			const expected = ['a', 'b'];
+
+			const actual = util.expandBraceExpansion('{a,{b,},}');
+
+			assert.deepStrictEqual(actual, expected);
+		});
 	});
 
 	describe('.getPatternParts', () => {

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -164,7 +164,10 @@ export function expandBraceExpansion(pattern: Pattern): Pattern[] {
 	 */
 	patterns.sort((a, b) => a.length - b.length);
 
-	return patterns;
+	/**
+	 * Micromatch can return an empty string in the case of patterns like `{a,}`.
+	 */
+	return patterns.filter((pattern) => pattern !== '');
 }
 
 export function getPatternParts(pattern: Pattern, options: MicromatchOptions): Pattern[] {


### PR DESCRIPTION
### What is the purpose of this pull request?
…

### What changes did you make? (Give an overview)
…
