### PR TITLE
ISSUE-190: Fix duplicate results for overlapping patterns due to a leading dot

### DIFF
--- a/__snapshots__/unique.e2e.js
+++ b/__snapshots__/unique.e2e.js
@@ -1,0 +1,29 @@
+exports['Options Unique {"pattern":["./file.md","file.md","*"],"options":{"cwd":"fixtures","unique":false}} (sync) 1'] = [
+  "./file.md",
+  "file.md",
+  "file.md"
+]
+
+exports['Options Unique {"pattern":["./file.md","file.md","*"],"options":{"cwd":"fixtures","unique":false}} (async) 1'] = [
+  "./file.md",
+  "file.md",
+  "file.md"
+]
+
+exports['Options Unique {"pattern":["./file.md","file.md","*"],"options":{"cwd":"fixtures","unique":false}} (stream) 1'] = [
+  "./file.md",
+  "file.md",
+  "file.md"
+]
+
+exports['Options Unique {"pattern":["./file.md","file.md","*"],"options":{"cwd":"fixtures","unique":true}} (sync) 1'] = [
+  "./file.md"
+]
+
+exports['Options Unique {"pattern":["./file.md","file.md","*"],"options":{"cwd":"fixtures","unique":true}} (async) 1'] = [
+  "./file.md"
+]
+
+exports['Options Unique {"pattern":["./file.md","file.md","*"],"options":{"cwd":"fixtures","unique":true}} (stream) 1'] = [
+  "./file.md"
+]

--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -86,6 +86,18 @@ describe('Providers → Filters → Entry', () => {
 				assert.ok(!actual);
 			});
 
+			it('should reject a duplicate entry when the two entries differ only by the leading dot segment', () => {
+				const first = tests.entry.builder().path('file.txt').file().build();
+				const second = tests.entry.builder().path('./file.txt').file().build();
+
+				const filter = getFilter({
+					positive: ['*', './file.txt']
+				});
+
+				assert.ok(filter(first));
+				assert.ok(!filter(second));
+			});
+
 			it('should accept a duplicate entry when an option is disabled', () => {
 				const filter = getFilter({
 					positive: ['**/*'],

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -18,7 +18,9 @@ export default class EntryFilter {
 	}
 
 	private _filter(entry: Entry, positiveRe: PatternRe[], negativeRe: PatternRe[]): boolean {
-		if (this._settings.unique && this._isDuplicateEntry(entry)) {
+		const filepath = utils.path.removeLeadingDotSegment(entry.path);
+
+		if (this._settings.unique && this._isDuplicateEntry(filepath)) {
 			return false;
 		}
 
@@ -26,27 +28,27 @@ export default class EntryFilter {
 			return false;
 		}
 
-		if (this._isSkippedByAbsoluteNegativePatterns(entry.path, negativeRe)) {
+		if (this._isSkippedByAbsoluteNegativePatterns(filepath, negativeRe)) {
 			return false;
 		}
 
 		const isDirectory = entry.dirent.isDirectory();
 
-		const isMatched = this._isMatchToPatterns(entry.path, positiveRe, isDirectory) && !this._isMatchToPatterns(entry.path, negativeRe, isDirectory);
+		const isMatched = this._isMatchToPatterns(filepath, positiveRe, isDirectory) && !this._isMatchToPatterns(filepath, negativeRe, isDirectory);
 
 		if (this._settings.unique && isMatched) {
-			this._createIndexRecord(entry);
+			this._createIndexRecord(filepath);
 		}
 
 		return isMatched;
 	}
 
-	private _isDuplicateEntry(entry: Entry): boolean {
-		return this.index.has(entry.path);
+	private _isDuplicateEntry(filepath: string): boolean {
+		return this.index.has(filepath);
 	}
 
-	private _createIndexRecord(entry: Entry): void {
-		this.index.set(entry.path, undefined);
+	private _createIndexRecord(filepath: string): void {
+		this.index.set(filepath, undefined);
 	}
 
 	private _onlyFileFilter(entry: Entry): boolean {
@@ -67,9 +69,7 @@ export default class EntryFilter {
 		return utils.pattern.matchAny(fullpath, patternsRe);
 	}
 
-	private _isMatchToPatterns(entryPath: string, patternsRe: PatternRe[], isDirectory: boolean): boolean {
-		const filepath = utils.path.removeLeadingDotSegment(entryPath);
-
+	private _isMatchToPatterns(filepath: string, patternsRe: PatternRe[], isDirectory: boolean): boolean {
 		// Trying to match files and directories by patterns.
 		const isMatched = utils.pattern.matchAny(filepath, patternsRe);
 

--- a/src/tests/e2e/options/unique.e2e.ts
+++ b/src/tests/e2e/options/unique.e2e.ts
@@ -1,0 +1,20 @@
+import * as runner from '../runner';
+
+runner.suite('Options Unique', {
+	tests: [
+		{
+			pattern: ['./file.md', 'file.md', '*'],
+			options: {
+				cwd: 'fixtures',
+				unique: false
+			}
+		},
+		{
+			pattern: ['./file.md', 'file.md', '*'],
+			options: {
+				cwd: 'fixtures',
+				unique: true
+			}
+		}
+	]
+});


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a partial fix for #190. This pull request fix duplicate results for overlapping patterns due to a leading dot, as mentioned in https://github.com/mrmlnc/fast-glob/issues/190#issuecomment-502436643.

### What changes did you make? (Give an overview)

Do not use `path.normalize` because it is an expensive function in terms of execution time.  For 10_000 entries - 3ms; 100_000 – 10ms; 1_000_000 – 80ms.

```js
// utils.path.removeLeadingDotSegment
fg: 352.983ms
183249

// path.normalize
fg: 493.967ms
183249
```

Uh, oh.

If there are issues on this topic, it will be necessary to consider the possibility of normalizing patterns at the task creation stage.