### PR TITLE
Use native fs.Dirent

### DIFF
--- a/src/readers/reader.spec.ts
+++ b/src/readers/reader.spec.ts
@@ -1,11 +1,10 @@
 import * as assert from 'assert';
-import * as fs from 'fs';
 import * as path from 'path';
 
 import { Stats, StatsMode } from '@nodelib/fs.macchiato';
 
 import Settings, { Options } from '../settings';
-import { Entry, Pattern } from '../types';
+import { Entry, FsStats, Pattern } from '../types';
 import Reader from './reader';
 
 class TestReader extends Reader<never[]> {
@@ -25,7 +24,7 @@ class TestReader extends Reader<never[]> {
 		return this._getFullEntryPath(filepath);
 	}
 
-	public makeEntry(stats: fs.Stats, pattern: Pattern): Entry {
+	public makeEntry(stats: FsStats, pattern: Pattern): Entry {
 		return this._makeEntry(stats, pattern);
 	}
 }

--- a/src/readers/reader.ts
+++ b/src/readers/reader.ts
@@ -1,10 +1,9 @@
-import * as fs from 'fs';
 import * as path from 'path';
 
 import * as fsStat from '@nodelib/fs.stat';
 
 import Settings from '../settings';
-import { Entry, ErrnoException, Pattern, ReaderOptions } from '../types';
+import { Entry, ErrnoException, FsStats, Pattern, ReaderOptions } from '../types';
 import * as utils from '../utils';
 
 export default abstract class Reader<T> {
@@ -23,7 +22,7 @@ export default abstract class Reader<T> {
 		return path.resolve(this._settings.cwd, filepath);
 	}
 
-	protected _makeEntry(stats: fs.Stats, pattern: Pattern): Entry {
+	protected _makeEntry(stats: FsStats, pattern: Pattern): Entry {
 		const entry: Entry = {
 			name: pattern,
 			path: pattern,

--- a/src/readers/stream.ts
+++ b/src/readers/stream.ts
@@ -1,10 +1,9 @@
-import * as fs from 'fs';
 import { PassThrough, Readable } from 'stream';
 
 import * as fsStat from '@nodelib/fs.stat';
 import * as fsWalk from '@nodelib/fs.walk';
 
-import { Entry, ErrnoException, Pattern, ReaderOptions } from '../types';
+import { Entry, ErrnoException, FsStats, Pattern, ReaderOptions } from '../types';
 import Reader from './reader';
 
 export default class ReaderStream extends Reader<Readable> {
@@ -55,7 +54,7 @@ export default class ReaderStream extends Reader<Readable> {
 			});
 	}
 
-	private _getStat(filepath: string): Promise<fs.Stats> {
+	private _getStat(filepath: string): Promise<FsStats> {
 		return new Promise((resolve, reject) => {
 			this._stat(filepath, this._fsStatSettings, (error: NodeJS.ErrnoException | null, stats) => {
 				return error === null ? resolve(stats) : reject(error);

--- a/src/readers/sync.ts
+++ b/src/readers/sync.ts
@@ -1,9 +1,7 @@
-import * as fs from 'fs';
-
 import * as fsStat from '@nodelib/fs.stat';
 import * as fsWalk from '@nodelib/fs.walk';
 
-import { Entry, ErrnoException, Pattern, ReaderOptions } from '../types';
+import { Entry, ErrnoException, FsStats, Pattern, ReaderOptions } from '../types';
 import Reader from './reader';
 
 export default class ReaderSync extends Reader<Entry[]> {
@@ -45,7 +43,7 @@ export default class ReaderSync extends Reader<Entry[]> {
 		}
 	}
 
-	private _getStat(filepath: string): fs.Stats {
+	private _getStat(filepath: string): FsStats {
 		return this._statSync(filepath, this._fsStatSettings);
 	}
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,10 @@
+import * as fs from 'fs';
 import * as fsWalk from '@nodelib/fs.walk';
 
 export type ErrnoException = NodeJS.ErrnoException;
 
+export type FsDirent = fs.Dirent;
+export type FsStats = fs.Stats;
 export type Entry = fsWalk.Entry;
 export type EntryItem = string | Entry;
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

In addition to the changes to @nodelib, use native `fs.Dirent` instead of our own implementation. This is necessary to eliminate the difference between the behavior of Node.js internal modules and this package.