### PR TITLE
ISSUE-370: Do not cast the path to POSIX style

### DIFF
--- a/src/providers/transformers/entry.spec.ts
+++ b/src/providers/transformers/entry.spec.ts
@@ -3,7 +3,6 @@ import * as path from 'node:path';
 
 import Settings from '../../settings';
 import * as tests from '../../tests';
-import * as utils from '../../utils';
 import EntryTransformer from './entry';
 
 import type { EntryTransformerFunction } from '../../types';
@@ -64,8 +63,7 @@ describe('Providers → Transformers → Entry', () => {
 			const transformer = getTransformer({ absolute: true });
 			const entry = tests.entry.builder().path('root/file.txt').file().build();
 
-			const fullpath = path.join(process.cwd(), 'root', 'file.txt');
-			const expected = utils.path.unixify(fullpath);
+			const expected = path.join(process.cwd(), 'root', 'file.txt');
 
 			const actual = transformer(entry);
 
@@ -87,8 +85,7 @@ describe('Providers → Transformers → Entry', () => {
 			const transformer = getTransformer({ absolute: true, markDirectories: true });
 			const entry = tests.entry.builder().path('root/directory').directory().build();
 
-			const fullpath = path.join(process.cwd(), 'root', 'directory', '/');
-			const expected = utils.path.unixify(fullpath);
+			const expected = path.join(process.cwd(), 'root', 'directory', '/');
 
 			const actual = transformer(entry);
 

--- a/src/providers/transformers/entry.ts
+++ b/src/providers/transformers/entry.ts
@@ -24,6 +24,7 @@ export default class EntryTransformer {
 
 		if (this.#settings.absolute) {
 			filepath = utils.path.makeAbsolute(this.#settings.cwd, filepath);
+			filepath = utils.string.flatHeavilyConcatenatedString(filepath);
 		}
 
 		if (this.#settings.markDirectories && entry.dirent.isDirectory()) {

--- a/src/providers/transformers/entry.ts
+++ b/src/providers/transformers/entry.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path';
+
 import * as utils from '../../utils';
 
 import type Settings from '../../settings';
@@ -5,9 +7,12 @@ import type { Entry, EntryItem, EntryTransformerFunction } from '../../types';
 
 export default class EntryTransformer {
 	readonly #settings: Settings;
+	readonly #pathSeparatorSymbol: string;
 
 	constructor(settings: Settings) {
 		this.#settings = settings;
+
+		this.#pathSeparatorSymbol = this.#getPathSeparatorSymbol();
 	}
 
 	public getTransformer(): EntryTransformerFunction {
@@ -19,11 +24,10 @@ export default class EntryTransformer {
 
 		if (this.#settings.absolute) {
 			filepath = utils.path.makeAbsolute(this.#settings.cwd, filepath);
-			filepath = utils.path.unixify(filepath);
 		}
 
 		if (this.#settings.markDirectories && entry.dirent.isDirectory()) {
-			filepath += '/';
+			filepath += this.#pathSeparatorSymbol;
 		}
 
 		if (!this.#settings.objectMode) {
@@ -34,5 +38,9 @@ export default class EntryTransformer {
 			...entry,
 			path: filepath,
 		};
+	}
+
+	#getPathSeparatorSymbol(): string {
+		return this.#settings.absolute ? path.sep : '/';
 	}
 }

--- a/src/tests/e2e/options/absolute.e2e.ts
+++ b/src/tests/e2e/options/absolute.e2e.ts
@@ -2,10 +2,15 @@ import * as path from 'node:path';
 
 import * as runner from '../runner';
 
-const CWD = process.cwd().replaceAll('\\', '/');
+const CWD = process.cwd();
+const CWD_POSIX = CWD.replaceAll('\\', '/');
 
 function resultTransform(item: string): string {
-	return item.replace(CWD, '<root>');
+	return item
+		.replace(CWD, '<root>')
+		// Backslashes are used on Windows.
+		// The `fixtures` directory is under our control, so we are confident that the conversions are correct.
+		.replaceAll(/[/\\]/g, '/');
 }
 
 runner.suite('Options Absolute', {
@@ -60,14 +65,14 @@ runner.suite('Options Absolute (ignore)', {
 		{
 			pattern: 'fixtures/*',
 			options: {
-				ignore: [path.posix.join(CWD, 'fixtures', '*')],
+				ignore: [path.posix.join(CWD_POSIX, 'fixtures', '*')],
 				absolute: true,
 			},
 		},
 		{
 			pattern: 'fixtures/**',
 			options: {
-				ignore: [path.posix.join(CWD, 'fixtures', '*')],
+				ignore: [path.posix.join(CWD_POSIX, 'fixtures', '*')],
 				absolute: true,
 			},
 			issue: 47,
@@ -125,7 +130,7 @@ runner.suite('Options Absolute (cwd & ignore)', {
 		{
 			pattern: '*',
 			options: {
-				ignore: [path.posix.join(CWD, 'fixtures', '*')],
+				ignore: [path.posix.join(CWD_POSIX, 'fixtures', '*')],
 				cwd: 'fixtures',
 				absolute: true,
 			},
@@ -133,7 +138,7 @@ runner.suite('Options Absolute (cwd & ignore)', {
 		{
 			pattern: '**',
 			options: {
-				ignore: [path.posix.join(CWD, 'fixtures', '*')],
+				ignore: [path.posix.join(CWD_POSIX, 'fixtures', '*')],
 				cwd: 'fixtures',
 				absolute: true,
 			},
@@ -141,7 +146,7 @@ runner.suite('Options Absolute (cwd & ignore)', {
 		{
 			pattern: '**',
 			options: {
-				ignore: [path.posix.join(CWD, 'fixtures', '**')],
+				ignore: [path.posix.join(CWD_POSIX, 'fixtures', '**')],
 				cwd: 'fixtures',
 				absolute: true,
 			},

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -4,16 +4,6 @@ import * as path from 'node:path';
 import * as util from './path';
 
 describe('Utils → Path', () => {
-	describe('.unixify', () => {
-		it('should return path with converted slashes', () => {
-			const expected = 'directory/nested/file.md';
-
-			const actual = util.unixify('directory\\nested/file.md');
-
-			assert.strictEqual(actual, expected);
-		});
-	});
-
 	describe('.makeAbsolute', () => {
 		it('should return absolute filepath', () => {
 			const expected = path.join(process.cwd(), 'file.md');

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -24,13 +24,6 @@ const DOS_DEVICE_PATH_RE = /^\\\\(?<path>[.?])/;
  */
 const WINDOWS_BACKSLASHES_RE = /\\(?![!()+@{}])/g;
 
-/**
- * Designed to work only with simple paths: `dir\\file`.
- */
-export function unixify(filepath: string): string {
-	return filepath.replaceAll('\\', '/');
-}
-
 export function makeAbsolute(cwd: string, filepath: string): string {
 	return path.resolve(cwd, filepath);
 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -5,3 +5,16 @@ export function isString(input: unknown): input is string {
 export function isEmpty(input: string): boolean {
 	return input === '';
 }
+
+/**
+ * Flattens the underlying C structures of a concatenated JavaScript string.
+ *
+ * More details: https://github.com/davidmarkclements/flatstr
+ */
+export function flatHeavilyConcatenatedString(input: string): string {
+	// @ts-expect-error Another solution can be `.trim`, but it changes the string.
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions, no-bitwise, unicorn/prefer-math-trunc
+	input | 0;
+
+	return input;
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

Addressed to several issues: #370, #379.

The main purpose of these changes is to stop casting the path to POSIX style (even on Windows) when the `absolute` option is enabled.

Current cases:

* `test-a@(\\\\)/test.js` (#379)
* #370

### What changes did you make? (Give an overview)
…
