### PR TITLE
fix: escape square braces on Windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,10 @@ Returns the path with escaped special characters depending on the platform.
   * `@+!` before the opening parenthesis;
   * `\\` before non-special characters;
 * Windows:
-  * `(){}`
+  * `(){}[]`
   * `!` at the beginning of line;
   * `@+!` before the opening parenthesis;
-  * Characters like `*?|[]` cannot be used in the path ([windows_naming_conventions][windows_naming_conventions]), so they will not be escaped;
+  * Characters like `*?|` cannot be used in the path ([windows_naming_conventions][windows_naming_conventions]), so they will not be escaped;
 
 ```js
 fg.escapePath('!abc');
@@ -283,7 +283,7 @@ fg.win32.escapePath('C:\\Program Files (x86)\\**\\*');
 Converts a path to a pattern depending on the platform, including special character escaping.
 
 * Posix. Works similarly to the `fg.posix.escapePath` method.
-* Windows. Works similarly to the `fg.win32.escapePath` method, additionally converting backslashes to forward slashes in cases where they are not escape characters (`!()+@{}`).
+* Windows. Works similarly to the `fg.win32.escapePath` method, additionally converting backslashes to forward slashes in cases where they are not escape characters (`!()+@{}[]`).
 
 ```js
 fg.convertPathToPattern('[OpenSource] mrmlnc – fast-glob (Deluxe Edition) 2014') + '/*.flac';

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -53,6 +53,7 @@ describe('Utils → Path', () => {
 			assert.strictEqual(util.escapeWindowsPath('!abc'), '\\!abc');
 			assert.strictEqual(util.escapeWindowsPath('()'), '\\(\\)');
 			assert.strictEqual(util.escapeWindowsPath('{}'), '\\{\\}');
+			assert.strictEqual(util.escapeWindowsPath('[]'), '\\[\\]');
 			assert.strictEqual(util.escapeWindowsPath('@('), '\\@\\(');
 			assert.strictEqual(util.escapeWindowsPath('!('), '\\!\\(');
 			assert.strictEqual(util.escapeWindowsPath('+('), '\\+\\(');
@@ -103,6 +104,8 @@ describe('Utils → Path', () => {
 			assert.strictEqual(util.convertWindowsPathToPattern('\\)\\'), '\\)/');
 			assert.strictEqual(util.convertWindowsPathToPattern('\\{\\'), '\\{/');
 			assert.strictEqual(util.convertWindowsPathToPattern('\\}\\'), '\\}/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\[\\'), '\\[/');
+			assert.strictEqual(util.convertWindowsPathToPattern('\\]\\'), '\\]/');
 
 			assert.strictEqual(util.convertWindowsPathToPattern('.\\*'), './*');
 			assert.strictEqual(util.convertWindowsPathToPattern('.\\**'), './**');

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -7,11 +7,11 @@ const IS_WINDOWS_PLATFORM = os.platform() === 'win32';
 const LEADING_DOT_SEGMENT_CHARACTERS_COUNT = 2; // ./ or .\\
 /**
  * All non-escaped special characters.
- * Posix: ()*?[\]{|}, !+@ before (, ! at the beginning, \\ before non-special characters.
- * Windows: (){}, !+@ before (, ! at the beginning.
+ * Posix: ()*?[]{|}, !+@ before (, ! at the beginning, \\ before non-special characters.
+ * Windows: (){}[], !+@ before (, ! at the beginning.
  */
 const POSIX_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
-const WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[(){}]|^!|[!+@](?=\())/g;
+const WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g;
 /**
  * The device path (\\.\ or \\?\).
  * https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths
@@ -22,7 +22,7 @@ const DOS_DEVICE_PATH_RE = /^\\\\(?<path>[.?])/;
  * Windows: !()+@{}
  * https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
  */
-const WINDOWS_BACKSLASHES_RE = /\\(?![!()+@{}])/g;
+const WINDOWS_BACKSLASHES_RE = /\\(?![!()+@[\]{}])/g;
 
 export function makeAbsolute(cwd: string, filepath: string): string {
 	return path.resolve(cwd, filepath);


### PR DESCRIPTION
### What is the purpose of this pull request?

On Windows, you can use square brackets in file paths.

### What changes did you make? (Give an overview)
…
