### PR TITLE
Remove the concurrency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This package provides methods for traversing the file system and returning pathn
 	* [convertPathToPattern](#convertpathtopatternpath)
 * [Options](#options-3)
   * [Common](#common)
-    * [concurrency](#concurrency)
     * [cwd](#cwd)
     * [deep](#deep)
     * [followSymbolicLinks](#followsymboliclinks)
@@ -306,31 +305,6 @@ fg.win32.convertPathToPattern('\\\\?\\c:\\Program Files (x86)') + '/**/*';
 ## Options
 
 ### Common options
-
-#### concurrency
-
-* Type: `number`
-* Default: `os.cpus().length`
-
-Specifies the maximum number of concurrent requests from a reader to read directories.
-
-> :book: The higher the number, the higher the performance and load on the file system. If you want to read in quiet mode, set the value to a comfortable number or `1`.
-
-<details>
-
-<summary>More details</summary>
-
-In Node, there are [two types of threads][nodejs_thread_pool]: Event Loop (code) and a Thread Pool (fs, dns, …). The thread pool size controlled by the `UV_THREADPOOL_SIZE` environment variable. Its default size is 4 ([documentation][libuv_thread_pool]). The pool is one for all tasks within a single Node process.
-
-Any code can make 4 real concurrent accesses to the file system. The rest of the FS requests will wait in the queue.
-
-> :book: Each new instance of FG in the same Node process will use the same Thread pool.
-
-But this package also has the `concurrency` option. This option allows you to control the number of concurrent accesses to the FS at the package level. By default, this package has a value equal to the number of cores available for the current Node process. This allows you to set a value smaller than the pool size (`concurrency: 1`) or, conversely, to prepare tasks for the pool queue more quickly (`concurrency: Number.POSITIVE_INFINITY`).
-
-So, in fact, this package can **only make 4 concurrent requests to the FS**. You can increase this value by using an environment variable (`UV_THREADPOOL_SIZE`), but in practice this does not give a multiple advantage.
-
-</details>
 
 #### cwd
 

--- a/src/benchmark/suites/product/async.ts
+++ b/src/benchmark/suites/product/async.ts
@@ -33,7 +33,6 @@ class Glob {
 			cwd: this.#cwd,
 			unique: false,
 			followSymbolicLinks: false,
-			concurrency: Number.POSITIVE_INFINITY,
 		}));
 	}
 

--- a/src/benchmark/suites/product/stream.ts
+++ b/src/benchmark/suites/product/stream.ts
@@ -49,7 +49,6 @@ class Glob {
 			cwd: this.#cwd,
 			unique: false,
 			followSymbolicLinks: false,
-			concurrency: Number.POSITIVE_INFINITY,
 		});
 
 		const action = new Promise<string[]>((resolve, reject) => {

--- a/src/benchmark/suites/regression/async.ts
+++ b/src/benchmark/suites/regression/async.ts
@@ -20,7 +20,6 @@ class Glob {
 		this.#options = {
 			unique: false,
 			followSymbolicLinks: false,
-			concurrency: Number.POSITIVE_INFINITY,
 			...options,
 		};
 	}

--- a/src/benchmark/suites/regression/stream.ts
+++ b/src/benchmark/suites/regression/stream.ts
@@ -20,7 +20,6 @@ class Glob {
 		this.#options = {
 			unique: false,
 			followSymbolicLinks: false,
-			concurrency: Number.POSITIVE_INFINITY,
 			...options,
 		};
 	}

--- a/src/providers/provider.spec.ts
+++ b/src/providers/provider.spec.ts
@@ -75,7 +75,6 @@ describe('Providers → Provider', () => {
 			const actual = provider.getReaderOptions(task);
 
 			assert.strictEqual(actual.basePath, '');
-			assert.strictEqual(actual.concurrency, settings.concurrency);
 			assert.strictEqual(typeof actual.deepFilter, 'function');
 			assert.strictEqual(typeof actual.entryFilter, 'function');
 			assert.strictEqual(typeof actual.errorFilter, 'function');

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -40,7 +40,6 @@ export abstract class Provider<T> {
 		return {
 			basePath,
 			pathSegmentSeparator: '/',
-			concurrency: this.#settings.concurrency,
 			deepFilter: this.deepFilter.getFilter(basePath, task.positive, task.negative),
 			entryFilter: this.entryFilter.getFilter(task.positive, task.negative),
 			errorFilter: this.errorFilter.getFilter(),

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -1,5 +1,4 @@
 import * as assert from 'node:assert';
-import * as os from 'node:os';
 
 import Settings, { DEFAULT_FILE_SYSTEM_ADAPTER } from './settings';
 
@@ -26,7 +25,6 @@ describe('Settings', () => {
 		assert.ok(settings.globstar);
 		assert.ok(settings.onlyFiles);
 		assert.ok(settings.unique);
-		assert.strictEqual(settings.concurrency, os.cpus().length);
 		assert.strictEqual(settings.cwd, process.cwd());
 	});
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,4 @@
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 
 import type { FileSystemAdapter, Pattern } from './types';
 
@@ -38,13 +37,6 @@ export interface Options {
 	 * @default true
 	 */
 	caseSensitiveMatch?: boolean;
-	/**
-	 * Specifies the maximum number of concurrent requests from a reader to read
-	 * directories.
-	 *
-	 * @default os.cpus().length
-	 */
-	concurrency?: number;
 	/**
 	 * The current working directory in which to search.
 	 *
@@ -153,7 +145,6 @@ export default class Settings {
 	public readonly baseNameMatch: boolean;
 	public readonly braceExpansion: boolean;
 	public readonly caseSensitiveMatch: boolean;
-	public readonly concurrency: number;
 	public readonly cwd: string;
 	public readonly deep: number;
 	public readonly dot: boolean;
@@ -177,11 +168,6 @@ export default class Settings {
 		this.baseNameMatch = options.baseNameMatch ?? false;
 		this.braceExpansion = options.braceExpansion ?? true;
 		this.caseSensitiveMatch = options.caseSensitiveMatch ?? true;
-		/**
-		 * The `os.cpus` method can return zero. We expect the number of cores to be greater than zero.
-		 * https://github.com/nodejs/node/blob/7faeddf23a98c53896f8b574a6e66589e8fb1eb8/lib/os.js#L106-L107
-		 */
-		this.concurrency = options.concurrency ?? Math.max(os.cpus().length, 1);
 		this.cwd = options.cwd ?? process.cwd();
 		this.deep = options.deep ?? Number.POSITIVE_INFINITY;
 		this.dot = options.dot ?? false;


### PR DESCRIPTION
### What is the purpose of this pull request?

In most cases, users do not use this option. There are only a couple of places on GitHub right now where users specify concurrency. The value passed there is `os.cpu().length`.

When specifying any value, the concurrency is always limited by the libuv library.

> In Node, there are [two types of threads][nodejs_thread_pool]: Event Loop (code) and a Thread Pool (fs, dns, …). The thread pool size controlled by the `UV_THREADPOOL_SIZE` environment variable. Its default size is 4 ([documentation][libuv_thread_pool]). The pool is one for all tasks within a single Node process.
> 
> Any code can make 4 real concurrent accesses to the file system. The rest of the FS requests will wait in the queue.
> 
> > :book: Each new instance of FG in the same Node process will use the same Thread pool.
> 
> But this package also has the `concurrency` option. This option allows you to control the number of concurrent accesses to the FS at the package level. By default, this package has a value equal to the number of cores available for the current Node process. This allows you to set a value smaller than the pool size (`concurrency: 1`) or, conversely, to prepare tasks for the pool queue more quickly (`concurrency: Number.POSITIVE_INFINITY`).
> 
> So, in fact, this package can **only make 4 concurrent requests to the FS**. You can increase this value by using an environment variable (`UV_THREADPOOL_SIZE`), but in practice this does not give a multiple advantage.

Currently, the `concurrency` option is not functioning correctly. For each task, a reader with its own queue is created. This means that if you specify the `concurrency:1` option and define three tasks, three calls will actually be sent to libuv thread pool instead of one.

https://github.com/mrmlnc/fast-glob/blob/4b71e29a69453931842642fd6b16778c46137a9f/src/index.ts#L27-L34

Currently, it would be easier for me to simply remove this option rather than create a shared queue for all tasks.

If anyone needs this opportunity, please let me know.

### What changes did you make? (Give an overview)
…
