### PR TITLE
absolute-fail Add failing test case.

### DIFF
--- a/src/tests/e2e/options/absolute.e2e.ts
+++ b/src/tests/e2e/options/absolute.e2e.ts
@@ -151,5 +151,16 @@ runner.suite('Options Absolute (cwd & ignore)', {
 				absolute: true,
 			},
 		},
+		{
+			pattern: 'file.md',
+			options: {
+				ignore: [path.posix.join('**', 'fixtures', '**')],
+				cwd: 'fixtures',
+				absolute: true,
+			},
+			expected: () => {
+				return ['<root>/fixtures/file.md'];
+			},
+		},
 	],
 });


### PR DESCRIPTION
### What is the purpose of this pull request?

To provide a failing test case for a problem regarding the absolute path pattern matching.
This is base for discussion regarding: https://github.com/mrmlnc/fast-glob/issues/441

### What changes did you make? (Give an overview)

Add a failing test.
