### PR TITLE
update micromatch to address CVE-2024-4068

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@nodelib/fs.walk": "^2.0.0",
     "glob-parent": "^6.0.2",
     "merge2": "^1.4.1",
-    "micromatch": "^4.0.5"
+    "micromatch": "^4.0.7"
   },
   "scripts": {
     "clean": "rimraf out build",


### PR DESCRIPTION
closes https://github.com/mrmlnc/fast-glob/issues/443

### What is the purpose of this pull request?
Fix a security vulnerability for `braces`

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-4068



### What changes did you make? (Give an overview)

Updated one line in packages.json to point to the fixed versions

https://github.com/micromatch/micromatch/issues/249 
https://github.com/micromatch/braces/issues/35

--> https://github.com/micromatch/braces/releases/tag/3.0.3

