### PR TITLE
Fix/abs negative patterns

### DIFF
--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -1,3 +1,5 @@
+import { isAbsolute } from 'node:path';
+
 import * as utils from '../../utils';
 
 import type Settings from '../../settings';
@@ -20,11 +22,15 @@ export default class EntryFilter {
 			...this.#micromatchOptions,
 			dot: true,
 		});
+		const absNegativeRe = utils.pattern.convertPatternsToRe(negative.filter((pattern) => isAbsolute(pattern)), {
+			...this.#micromatchOptions,
+			dot: true,
+		});
 
-		return (entry) => this.#filter(entry, positiveRe, negativeRe);
+		return (entry) => this.#filter(entry, positiveRe, negativeRe, absNegativeRe);
 	}
 
-	#filter(entry: Entry, positiveRe: PatternRe[], negativeRe: PatternRe[]): boolean {
+	#filter(entry: Entry, positiveRe: PatternRe[], negativeRe: PatternRe[], absNegativeRe: PatternRe[]): boolean {
 		const filepath = utils.path.removeLeadingDotSegment(entry.path);
 
 		if (this.#settings.unique && this.#isDuplicateEntry(filepath)) {
@@ -35,7 +41,7 @@ export default class EntryFilter {
 			return false;
 		}
 
-		if (this.#isSkippedByAbsoluteNegativePatterns(filepath, negativeRe)) {
+		if (this.#isSkippedByAbsoluteNegativePatterns(filepath, absNegativeRe)) {
 			return false;
 		}
 

--- a/src/tests/e2e/options/absolute.e2e.ts
+++ b/src/tests/e2e/options/absolute.e2e.ts
@@ -151,5 +151,16 @@ runner.suite('Options Absolute (cwd & ignore)', {
 				absolute: true,
 			},
 		},
+		{
+			pattern: 'file.md',
+			options: {
+				ignore: [path.posix.join('**', 'fixtures', '**')],
+				cwd: 'fixtures',
+				absolute: true,
+			},
+			expected: () => {
+				return ['<root>/fixtures/file.md'];
+			},
+		},
 	],
 });


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes #441

### What changes did you make? (Give an overview)

Use only absolute (negated) patterns when matching against absolute paths to skip in filter.

Without this fix, when using `absolute: true`, ignore patterns like `**/parent` may match ancestor path parts (in `cwd`), but not descendant path parts.

Example:

```ts
const options = {
  cwd: '/some/parent/cwd',
  absolute: true,
  ignore: ['**/parent']
}
```

When globbing `src/**/*.ts`, it would not match anything, because `**/parent` is a match against the full path.