### PR TITLE
docs: remove redundant example

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ const entries = await fg.glob(['.editorconfig', '**/index.js'], { dot: true });
 
 ```js
 fg.globSync(patterns, [options])
-fg.globSync(patterns, [options])
 ```
 
 Returns an array of matching entries.


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix a typo.

### What changes did you make? (Give an overview)

There is a redundant `fg.globSync(patterns, [options])` in the readme.
