### PR TITLE
ISSUE-441: apply absolute negative patterns to full path

### DIFF
--- a/__snapshots__/absolute.e2e.js
+++ b/__snapshots__/absolute.e2e.js
@@ -351,3 +351,15 @@ exports['Options Absolute (cwd & ignore) {"pattern":"**","options":{"ignore":["<
 exports['Options Absolute (cwd & ignore) {"pattern":"**","options":{"ignore":["<root>/fixtures/**"],"cwd":"fixtures","absolute":true}} (async) 1'] = []
 
 exports['Options Absolute (cwd & ignore) {"pattern":"**","options":{"ignore":["<root>/fixtures/**"],"cwd":"fixtures","absolute":true}} (stream) 1'] = []
+
+exports['Options Absolute (cwd & ignore) {"pattern":"file.md","options":{"ignore":["**/fixtures/**"],"cwd":"fixtures","absolute":true}} (sync) 1'] = [
+  "<root>/fixtures/file.md"
+]
+
+exports['Options Absolute (cwd & ignore) {"pattern":"file.md","options":{"ignore":["**/fixtures/**"],"cwd":"fixtures","absolute":true}} (async) 1'] = [
+  "<root>/fixtures/file.md"
+]
+
+exports['Options Absolute (cwd & ignore) {"pattern":"file.md","options":{"ignore":["**/fixtures/**"],"cwd":"fixtures","absolute":true}} (stream) 1'] = [
+  "<root>/fixtures/file.md"
+]

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test:e2e:stream": "mocha \"out/**/*.e2e.js\" -s 0 --grep \"\\(stream\\)\"",
     "_build:compile": "npm run clean && npm run compile",
     "build": "npm run _build:compile && npm run lint && npm test",
-    "watch": "npm run _build:compile -- --sourceMap --watch",
+    "watch": "npm run _build:compile -- -- --sourceMap --watch",
     "_bundle:dts": "tsc --emitDeclarationOnly --outDir ./build",
     "_bundle:ts": "esbuild --bundle ./src/index.ts --outfile=./build/index.js --platform=node --target=node16.14 --format=cjs",
     "_bundle:build": "npm run _bundle:dts && npm run _bundle:ts",

--- a/src/tests/e2e/options/absolute.e2e.ts
+++ b/src/tests/e2e/options/absolute.e2e.ts
@@ -126,6 +126,14 @@ runner.suite('Options Absolute (cwd & ignore)', {
 				absolute: true,
 			},
 		},
+		{
+			pattern: 'file.md',
+			options: {
+				ignore: [path.posix.join('**', 'fixtures', '**')],
+				cwd: 'fixtures',
+				absolute: true,
+			},
+		},
 
 		{
 			pattern: '*',

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -540,4 +540,18 @@ describe('Utils → Pattern', () => {
 			assert.strictEqual(action('///?/D:/'), '//?/D:/');
 		});
 	});
+
+	describe('.isAbsolute', () => {
+		it('should return true', () => {
+			const actual = util.isAbsolute('/directory/file.txt');
+
+			assert.ok(actual);
+		});
+
+		it('should return false', () => {
+			const actual = util.isAbsolute('directory/file.txt');
+
+			assert.ok(!actual);
+		});
+	});
 });

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -217,3 +217,22 @@ export function matchAny(entry: string, patternsRe: PatternRe[]): boolean {
 export function removeDuplicateSlashes(pattern: string): string {
 	return pattern.replaceAll(DOUBLE_SLASH_RE, '/');
 }
+
+export function partitionAbsoluteAndRelative(patterns: Pattern[]): [Pattern[], Pattern[]] {
+	const absolute: Pattern[] = [];
+	const relative: Pattern[] = [];
+
+	for (const pattern of patterns) {
+		if (isAbsolute(pattern)) {
+			absolute.push(pattern);
+		} else {
+			relative.push(pattern);
+		}
+	}
+
+	return [absolute, relative];
+}
+
+export function isAbsolute(pattern: string): boolean {
+	return path.isAbsolute(pattern);
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes #441, based on an idea from #445.

### What changes did you make? (Give an overview)

Use only absolute (negated) patterns when matching against absolute paths to skip in filter.