### PR TITLE
package.json: Refer to micromatch 4.0.8+ to address CVE-2024-4067 

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@nodelib/fs.walk": "^2.0.0",
     "glob-parent": "^6.0.2",
     "merge2": "^1.4.1",
-    "micromatch": "^4.0.7"
+    "micromatch": "^4.0.8"
   },
   "scripts": {
     "clean": "rimraf out build",


### PR DESCRIPTION
### What is the purpose of this pull request?

To avoid warnings about GHSA-952p-6rrq-rcjv aka CVE-2024-4067

I am a transitive user of fast-glob, so I figured it'd be nice to fix it here.

### What changes did you make? (Give an overview)

I pointed to the next patch release as direct dependency.
