### PR TITLE
fix: escape comma

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -258,9 +258,9 @@ describe('Package', () => {
 	describe('posix', () => {
 		describe('.escapePath', () => {
 			it('should return escaped path', () => {
-				const expected = '/directory/\\*\\*/\\*';
+				const expected = '/directory\\, /\\*\\*/\\*';
 
-				const actual = fg.posix.escapePath('/directory/*\\*/*');
+				const actual = fg.posix.escapePath('/directory, /*\\*/*');
 
 				assert.strictEqual(actual, expected);
 			});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -10,7 +10,7 @@ const LEADING_DOT_SEGMENT_CHARACTERS_COUNT = 2; // ./ or .\\
  * Posix: ()*?[]{|}, !+@ before (, ! at the beginning, \\ before non-special characters.
  * Windows: (){}[], !+@ before (, ! at the beginning.
  */
-const POSIX_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
+const POSIX_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()*,?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+,?@[\]{|}]))/g;
 const WINDOWS_UNESCAPED_GLOB_SYMBOLS_RE = /(?<escape>\\?)(?<symbols>[()[\]{}]|^!|[!+@](?=\())/g;
 /**
  * The device path (\\.\ or \\?\).


### PR DESCRIPTION
### What is the purpose of this pull request?

`escape` doesn't currently escape commas, meaning that paths containing commas can unexpectedly change the glob pattern.

### What changes did you make? (Give an overview)

I changed the regex to handle commas.