### PR TITLE
3.3.3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,9 @@
 	"extends": "mrmlnc",
 	"rules": {
 		"no-magic-numbers": "off",
-		"@typescript-eslint/no-magic-numbers": "off"
+		"@typescript-eslint/no-magic-numbers": "off",
+		"import/namespace": "off",
+		"import/no-deprecated": "off"
 	},
 	"overrides": [
 		{

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Indicates whether to traverse descendants of symbolic link directories when expa
 * Type: `FileSystemAdapter`
 * Default: `fs.*`
 
-Custom implementation of methods for working with the file system.
+Custom implementation of methods for working with the file system. Supports objects with enumerable properties only.
 
 ```ts
 export interface FileSystemAdapter {

--- a/__snapshots__/absolute.e2e.js
+++ b/__snapshots__/absolute.e2e.js
@@ -351,3 +351,15 @@ exports['Options Absolute (cwd & ignore) {"pattern":"**","options":{"ignore":["<
 exports['Options Absolute (cwd & ignore) {"pattern":"**","options":{"ignore":["<root>/fixtures/**"],"cwd":"fixtures","absolute":true}} (async) 1'] = []
 
 exports['Options Absolute (cwd & ignore) {"pattern":"**","options":{"ignore":["<root>/fixtures/**"],"cwd":"fixtures","absolute":true}} (stream) 1'] = []
+
+exports['Options Absolute (cwd & ignore) {"pattern":"file.md","options":{"ignore":["**/fixtures/**"],"cwd":"fixtures","absolute":true}} (sync) 1'] = [
+  "<root>/fixtures/file.md"
+]
+
+exports['Options Absolute (cwd & ignore) {"pattern":"file.md","options":{"ignore":["**/fixtures/**"],"cwd":"fixtures","absolute":true}} (async) 1'] = [
+  "<root>/fixtures/file.md"
+]
+
+exports['Options Absolute (cwd & ignore) {"pattern":"file.md","options":{"ignore":["**/fixtures/**"],"cwd":"fixtures","absolute":true}} (stream) 1'] = [
+  "<root>/fixtures/file.md"
+]

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@nodelib/fs.walk": "^1.2.3",
     "glob-parent": "^5.1.2",
     "merge2": "^1.3.0",
-    "micromatch": "^4.0.4"
+    "micromatch": "^4.0.8"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-mrmlnc": "^1.1.0",
     "execa": "^7.1.1",
     "fast-glob": "^3.0.4",
-    "fdir": "^6.0.1",
+    "fdir": "6.0.1",
     "glob": "^10.0.0",
     "hereby": "^1.8.1",
     "mocha": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:e2e:async": "mocha \"out/**/*.e2e.js\" -s 0 --grep \"\\(async\\)\"",
     "test:e2e:stream": "mocha \"out/**/*.e2e.js\" -s 0 --grep \"\\(stream\\)\"",
     "build": "npm run clean && npm run compile && npm run lint && npm test",
-    "watch": "npm run clean && npm run compile -- --sourceMap --watch",
+    "watch": "npm run clean && npm run compile -- -- --sourceMap --watch",
     "bench:async": "npm run bench:product:async && npm run bench:regression:async",
     "bench:stream": "npm run bench:product:stream && npm run bench:regression:stream",
     "bench:sync": "npm run bench:product:sync && npm run bench:regression:sync",

--- a/src/tests/e2e/options/absolute.e2e.ts
+++ b/src/tests/e2e/options/absolute.e2e.ts
@@ -121,6 +121,14 @@ runner.suite('Options Absolute (cwd & ignore)', {
 				absolute: true
 			}
 		},
+		{
+			pattern: 'file.md',
+			options: {
+				ignore: [path.posix.join('**', 'fixtures', '**')],
+				cwd: 'fixtures',
+				absolute: true
+			}
+		},
 
 		{
 			pattern: '*',

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -539,4 +539,18 @@ describe('Utils → Pattern', () => {
 			assert.strictEqual(action('///?/D:/'), '//?/D:/');
 		});
 	});
+
+	describe('.isAbsolute', () => {
+		it('should return true', () => {
+			const actual = util.isAbsolute('/directory/file.txt');
+
+			assert.ok(actual);
+		});
+
+		it('should return false', () => {
+			const actual = util.isAbsolute('directory/file.txt');
+
+			assert.ok(!actual);
+		});
+	});
 });

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -215,3 +215,22 @@ export function matchAny(entry: string, patternsRe: PatternRe[]): boolean {
 export function removeDuplicateSlashes(pattern: string): string {
 	return pattern.replace(DOUBLE_SLASH_RE, '/');
 }
+
+export function partitionAbsoluteAndRelative(patterns: Pattern[]): Pattern[][] {
+	const absolute: Pattern[] = [];
+	const relative: Pattern[] = [];
+
+	for (const pattern of patterns) {
+		if (isAbsolute(pattern)) {
+			absolute.push(pattern);
+		} else {
+			relative.push(pattern);
+		}
+	}
+
+	return [absolute, relative];
+}
+
+export function isAbsolute(pattern: string): boolean {
+	return path.isAbsolute(pattern);
+}


### PR DESCRIPTION
Noticed changes:

1. Refer to `micromatch@4.0.8` to avoid annoying npm audit spam;
2. Apply absolute negative patterns to full path instead of file path (#441);
3. Optimizing the patterns set matching by exiting early;