### PR TITLE
Add tinyglobby to product benchmark instead of fdir

### DIFF
--- a/herebyfile.mjs
+++ b/herebyfile.mjs
@@ -73,9 +73,9 @@ export const {
 	productStreamTask,
 	productSyncTask,
 } = {
-	productAsyncTask: makeBenchSuiteTask('product', 'async', PRODUCT_ASYNC_SUITE, ['fast-glob', 'node-glob', 'fdir', 'tinyglobby']),
+	productAsyncTask: makeBenchSuiteTask('product', 'async', PRODUCT_ASYNC_SUITE, ['fast-glob', 'node-glob', 'tinyglobby']),
 	productStreamTask: makeBenchSuiteTask('product', 'stream', PRODUCT_STREAM_SUITE, ['fast-glob', 'node-glob']),
-	productSyncTask: makeBenchSuiteTask('product', 'sync', PRODUCT_SYNC_SUITE, ['fast-glob', 'node-glob', 'fdir', 'tinyglobby']),
+	productSyncTask: makeBenchSuiteTask('product', 'sync', PRODUCT_SYNC_SUITE, ['fast-glob', 'node-glob', 'tinyglobby']),
 };
 
 export const {

--- a/herebyfile.mjs
+++ b/herebyfile.mjs
@@ -73,9 +73,9 @@ export const {
 	productStreamTask,
 	productSyncTask,
 } = {
-	productAsyncTask: makeBenchSuiteTask('product', 'async', PRODUCT_ASYNC_SUITE, ['fast-glob', 'node-glob', 'fdir']),
+	productAsyncTask: makeBenchSuiteTask('product', 'async', PRODUCT_ASYNC_SUITE, ['fast-glob', 'node-glob', 'fdir', 'tinyglobby']),
 	productStreamTask: makeBenchSuiteTask('product', 'stream', PRODUCT_STREAM_SUITE, ['fast-glob', 'node-glob']),
-	productSyncTask: makeBenchSuiteTask('product', 'sync', PRODUCT_SYNC_SUITE, ['fast-glob', 'node-glob', 'fdir']),
+	productSyncTask: makeBenchSuiteTask('product', 'sync', PRODUCT_SYNC_SUITE, ['fast-glob', 'node-glob', 'fdir', 'tinyglobby']),
 };
 
 export const {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-config-mrmlnc": "^5.0.0",
     "execa": "^7.2.0",
     "fast-glob": "^3.3.2",
-    "fdir": "^6.4.2",
     "glob": "^11.0.0",
     "hereby": "^1.10.0",
     "mocha": "^10.8.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rimraf": "^6.0.1",
     "sinon": "^19.0.2",
     "snap-shot-it": "^7.9.10",
+    "tinyglobby": "^0.2.10",
     "typescript": "^5.7.2"
   },
   "dependencies": {

--- a/src/benchmark/suites/product/async.ts
+++ b/src/benchmark/suites/product/async.ts
@@ -4,7 +4,7 @@ import * as bencho from 'bencho';
 
 import * as utils from '../../utils';
 
-type GlobImplementation = 'fast-glob' | 'fdir' | 'node-glob' | 'tinyglobby';
+type GlobImplementation = 'fast-glob' | 'node-glob' | 'tinyglobby';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GlobImplFunction = (...args: any[]) => Promise<unknown[]>;
 
@@ -34,19 +34,6 @@ class Glob {
 			unique: false,
 			followSymbolicLinks: false,
 		}));
-	}
-
-	public async measureFdir(): Promise<void> {
-		const { fdir: FdirBuilder } = await utils.importAndMeasure(utils.importFdir);
-
-		const fdir = new FdirBuilder()
-			.withBasePath()
-			.withRelativePaths()
-			// Other solutions do not include hidden files by default
-			.globWithOptions([this.#pattern], { dot: false })
-			.crawl(this.#cwd);
-
-		await this.#measure(() => fdir.withPromise());
 	}
 
 	public async measureTinyGlobby(): Promise<void> {
@@ -91,11 +78,6 @@ class Glob {
 
 		case 'fast-glob': {
 			await glob.measureFastGlob();
-			break;
-		}
-
-		case 'fdir': {
-			await glob.measureFdir();
 			break;
 		}
 

--- a/src/benchmark/suites/product/async.ts
+++ b/src/benchmark/suites/product/async.ts
@@ -4,7 +4,7 @@ import * as bencho from 'bencho';
 
 import * as utils from '../../utils';
 
-type GlobImplementation = 'fast-glob' | 'fdir' | 'node-glob';
+type GlobImplementation = 'fast-glob' | 'fdir' | 'node-glob' | 'tinyglobby';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GlobImplFunction = (...args: any[]) => Promise<unknown[]>;
 
@@ -49,6 +49,15 @@ class Glob {
 		await this.#measure(() => fdir.withPromise());
 	}
 
+	public async measureTinyGlobby(): Promise<void> {
+		const tinyglobby = await utils.importAndMeasure(utils.importTinyGlobby);
+
+		await this.#measure(() => tinyglobby.glob(this.#pattern, {
+			cwd: this.#cwd,
+			followSymbolicLinks: false,
+		}));
+	}
+
 	async #measure(function_: GlobImplFunction): Promise<void> {
 		const timeStart = utils.timeStart();
 
@@ -87,6 +96,11 @@ class Glob {
 
 		case 'fdir': {
 			await glob.measureFdir();
+			break;
+		}
+
+		case 'tinyglobby': {
+			await glob.measureTinyGlobby();
 			break;
 		}
 

--- a/src/benchmark/suites/product/sync.ts
+++ b/src/benchmark/suites/product/sync.ts
@@ -4,7 +4,7 @@ import * as bencho from 'bencho';
 
 import * as utils from '../../utils';
 
-type GlobImplementation = 'fast-glob' | 'fdir' | 'node-glob' | 'tinyglobby';
+type GlobImplementation = 'fast-glob' | 'node-glob' | 'tinyglobby';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GlobImplFunction = (...args: any[]) => unknown[];
 
@@ -34,19 +34,6 @@ class Glob {
 			unique: false,
 			followSymbolicLinks: false,
 		}));
-	}
-
-	public async measureFdir(): Promise<void> {
-		const { fdir: FdirBuilder } = await utils.importAndMeasure(utils.importFdir);
-
-		const fdir = new FdirBuilder()
-			.withBasePath()
-			.withRelativePaths()
-			// Other solutions do not include hidden files by default
-			.globWithOptions([this.#pattern], { dot: false })
-			.crawl(this.#cwd);
-
-		this.#measure(() => fdir.sync());
 	}
 
 	public async measureTinyGlobby(): Promise<void> {
@@ -91,11 +78,6 @@ class Glob {
 
 		case 'fast-glob': {
 			await glob.measureFastGlob();
-			break;
-		}
-
-		case 'fdir': {
-			await glob.measureFdir();
 			break;
 		}
 

--- a/src/benchmark/suites/product/sync.ts
+++ b/src/benchmark/suites/product/sync.ts
@@ -4,7 +4,7 @@ import * as bencho from 'bencho';
 
 import * as utils from '../../utils';
 
-type GlobImplementation = 'fast-glob' | 'fdir' | 'node-glob';
+type GlobImplementation = 'fast-glob' | 'fdir' | 'node-glob' | 'tinyglobby';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GlobImplFunction = (...args: any[]) => unknown[];
 
@@ -49,6 +49,15 @@ class Glob {
 		this.#measure(() => fdir.sync());
 	}
 
+	public async measureTinyGlobby(): Promise<void> {
+		const tinyglobby = await utils.importAndMeasure(utils.importTinyGlobby);
+
+		this.#measure(() => tinyglobby.globSync(this.#pattern, {
+			cwd: this.#cwd,
+			followSymbolicLinks: false,
+		}));
+	}
+
 	#measure(function_: GlobImplFunction): void {
 		const timeStart = utils.timeStart();
 
@@ -87,6 +96,11 @@ class Glob {
 
 		case 'fdir': {
 			await glob.measureFdir();
+			break;
+		}
+
+		case 'tinyglobby': {
+			await glob.measureTinyGlobby();
 			break;
 		}
 

--- a/src/benchmark/utils.ts
+++ b/src/benchmark/utils.ts
@@ -6,6 +6,7 @@ import type * as currentVersion from '..';
 import type * as previousVersion from 'fast-glob';
 import type * as glob from 'glob';
 import type * as fdir from 'fdir';
+import type * as tg from 'tinyglobby';
 
 export function timeStart(): number {
 	return performance.now();
@@ -33,6 +34,10 @@ export function importNodeGlob(): Promise<typeof glob> {
 
 export function importFdir(): Promise<typeof fdir> {
 	return import('fdir');
+}
+
+export function importTinyGlobby(): Promise<typeof tg> {
+	return import('tinyglobby');
 }
 
 export async function importAndMeasure<T>(function_: () => Promise<T>): Promise<T> {

--- a/src/benchmark/utils.ts
+++ b/src/benchmark/utils.ts
@@ -5,7 +5,6 @@ import * as bencho from 'bencho';
 import type * as currentVersion from '..';
 import type * as previousVersion from 'fast-glob';
 import type * as glob from 'glob';
-import type * as fdir from 'fdir';
 import type * as tg from 'tinyglobby';
 
 export function timeStart(): number {
@@ -30,10 +29,6 @@ export function importPreviousFastGlob(): Promise<typeof previousVersion> {
 
 export function importNodeGlob(): Promise<typeof glob> {
 	return import('glob');
-}
-
-export function importFdir(): Promise<typeof fdir> {
-	return import('fdir');
 }
 
 export function importTinyGlobby(): Promise<typeof tg> {

--- a/src/tests/e2e/runner.ts
+++ b/src/tests/e2e/runner.ts
@@ -1,7 +1,7 @@
 /* eslint-disable mocha/no-setup-in-describe */
 import * as assert from 'node:assert';
 
-import snapshotIt from 'snap-shot-it';
+import * as snapshotIt from 'snap-shot-it';
 import { describe, it } from 'mocha';
 
 import * as fg from '../..';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
 
 		"forceConsistentCasingInFileNames": true,
 		"verbatimModuleSyntax": false,
-		"esModuleInterop": true,
 
 		"downlevelIteration": true,
 		"declaration": true,


### PR DESCRIPTION
First, the `fdir` package is not a glob solution. Yes, it can be used as a glob, but it simply uses `picomatch` to find matching paths and does not apply any heuristics. This is clearly visible in our benchmarks. Rather, it is a competitor to `@nodelib/fs.walk`, not `fast-glob`.

```js
Using ~/work/fast-glob/fast-glob/herebyfile.mjs to run bench:product:async
Starting bench:product:async:flatten
Label              import.time (time)  time (time)       memory (memory)    entries (value)  process.time (time)
-----------------  ------------------  ----------------  -----------------  ---------------  -------------------
async fast-glob *  10.146ms ±2.178%    4.414ms ±1.719%   5.389 MiB ±0.000%  6 ±0.000%        43.573ms ±1.645%   
async node-glob *  14.556ms ±6.243%    6.483ms ±3.063%   5.137 MiB ±0.293%  6 ±0.000%        50.223ms ±2.531%   
async fdir *       9.138ms ±8.759%     43.941ms ±4.199%  6.380 MiB ±7.375%  6 ±0.000%        85.082ms ±3.145%   

Finished bench:product:async:flatten in 35.8s
Starting bench:product:async:deep
Label               import.time (time)  time (time)        memory (memory)     entries (value)  process.time (time)
------------------  ------------------  -----------------  ------------------  ---------------  -------------------
async fast-glob **  10.139ms ±1.517%    67.479ms ±4.974%   10.663 MiB ±0.800%  17321 ±0.000%    109.259ms ±4.383%  
async node-glob **  14.292ms ±5.569%    159.467ms ±3.012%  25.656 MiB ±2.180%  17321 ±0.000%    209.310ms ±2.666%  
async fdir **       8.980ms ±8.204%     51.330ms ±2.906%   8.832 MiB ±1.093%   17321 ±0.000%    92.592ms ±1.898%   

Finished bench:product:async:deep in 1m 22.2s
Starting bench:product:async:partial_flatten
Label                                            import.time (time)  time (time)       memory (memory)    entries (value)  process.time (time)
-----------------------------------------------  ------------------  ----------------  -----------------  ---------------  -------------------
async fast-glob {fixtures,out}/{first,second}/*  10.243ms ±1.576%    8.927ms ±1.916%   5.044 MiB ±0.126%  2 ±0.000%        48.568ms ±1.513%   
async node-glob {fixtures,out}/{first,second}/*  14.351ms ±5.512%    8.226ms ±2.810%   5.264 MiB ±0.374%  2 ±0.000%        51.684ms ±2.104%   
async fdir {fixtures,out}/{first,second}/*       9.071ms ±8.824%     43.779ms ±3.488%  6.503 MiB ±6.242%  2 ±0.000%        86.557ms ±3.088%   

Finished bench:product:async:partial_flatten in 37.4s
Starting bench:product:async:partial_deep
Label                              import.time (time)  time (time)       memory (memory)    entries (value)  process.time (time)
---------------------------------  ------------------  ----------------  -----------------  ---------------  -------------------
async fast-glob {fixtures,out}/**  10.203ms ±4.545%    9.877ms ±5.598%   5.239 MiB ±0.085%  178 ±0.000%      48.916ms ±3.786%   
async node-glob {fixtures,out}/**  14.350ms ±5.594%    10.967ms ±2.434%  5.546 MiB ±0.295%  178 ±0.000%      54.478ms ±2.044%   
async fdir {fixtures,out}/**       9.029ms ±8.476%     43.141ms ±2.229%  6.492 MiB ±6.712%  178 ±0.000%      85.306ms ±1.786%   

Finished bench:product:async:partial_deep in 37.7s
Starting bench:product:async
Finished bench:product:async in 1ms
Completed bench:product:async in 3m 13.3s
```

Secondly, another glob package appeared in the ring, which is based on the `fdir` package. So, great! I'll stay here and observe.

I'm simply replacing `fdir` with `tinyglobby`.