### PR TITLE
perf: optimizing the patterns set matching by exiting early

### DIFF
--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -79,21 +79,39 @@ export default class EntryFilter {
 	}
 
 	#isMatchToPatternsSet(filepath: string, patterns: PatternsRegexSet, isDirectory: boolean): boolean {
-		let fullpath = filepath;
-
-		if (patterns.negative.absolute.length > 0) {
-			fullpath = utils.path.makeAbsolute(this.#settings.cwd, filepath);
+		const isMatched = this.#isMatchToPatterns(filepath, patterns.positive.all, isDirectory);
+		if (!isMatched) {
+			return false;
 		}
 
-		const isMatched = this.#isMatchToPatterns(filepath, patterns.positive.all, isDirectory);
+		const isMatchedByRelativeNegative = this.#isMatchToPatterns(filepath, patterns.negative.relative, isDirectory);
+		if (isMatchedByRelativeNegative) {
+			return false;
+		}
 
-		return isMatched && !(
-			this.#isMatchToPatterns(filepath, patterns.negative.relative, isDirectory) ||
-			this.#isMatchToPatterns(fullpath, patterns.negative.absolute, isDirectory)
-		);
+		const isMatchedByAbsoluteNegative = this.#isMatchToAbsoluteNegative(filepath, patterns.negative.absolute, isDirectory);
+		if (isMatchedByAbsoluteNegative) {
+			return false;
+		}
+
+		return true;
+	}
+
+	#isMatchToAbsoluteNegative(filepath: string, patternsRe: PatternRe[], isDirectory: boolean): boolean {
+		if (patternsRe.length === 0) {
+			return false;
+		}
+
+		const fullpath = utils.path.makeAbsolute(this.#settings.cwd, filepath);
+
+		return this.#isMatchToPatterns(fullpath, patternsRe, isDirectory);
 	}
 
 	#isMatchToPatterns(filepath: string, patternsRe: PatternRe[], isDirectory: boolean): boolean {
+		if (patternsRe.length === 0) {
+			return false;
+		}
+
 		// Trying to match files and directories by patterns.
 		const isMatched = utils.pattern.matchAny(filepath, patternsRe);
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Optimization of deep directory asynchronous crawls by ~5-10%.

```js
// Without options (~5%)

Label              import.time (time)  time (time)       memory (memory)     entries (value)  process.time (time)
-----------------  ------------------  ----------------  ------------------  ---------------  -------------------
async current **   26.208ms ±3.187%    64.608ms ±2.053%  11.031 MiB ±4.829%  17452 ±0.000%    123.354ms ±2.018%  
async previous **  24.411ms ±3.881%    66.132ms ±4.072%  11.163 MiB ±6.652%  17452 ±0.000%    120.214ms ±2.595% 

// With absolute: true (~10%)

Label              import.time (time)  time (time)        memory (memory)      entries (value)  process.time (time)
-----------------  ------------------  -----------------  -------------------  ---------------  -------------------
async current **   26.501ms ±3.421%    106.862ms ±5.315%  20.176 MiB ±11.108%  17452 ±0.000%    165.816ms ±3.340%  
async previous **  24.319ms ±4.100%    119.074ms ±1.658%  15.928 MiB ±6.148%   17452 ±0.000%    174.286ms ±1.540% 
```

### What changes did you make? (Give an overview)

It is not necessary to perform unnecessary actions if they do not fit into a positive pattern or if there is no relevant pattern to follow by type.