### PR TITLE
chore: introduce native glob benchmark

### DIFF
--- a/herebyfile.mjs
+++ b/herebyfile.mjs
@@ -73,9 +73,9 @@ export const {
 	productStreamTask,
 	productSyncTask,
 } = {
-	productAsyncTask: makeBenchSuiteTask('product', 'async', PRODUCT_ASYNC_SUITE, ['fast-glob', 'node-glob', 'tinyglobby']),
+	productAsyncTask: makeBenchSuiteTask('product', 'async', PRODUCT_ASYNC_SUITE, ['fast-glob', 'node-glob', 'tinyglobby', 'native']),
 	productStreamTask: makeBenchSuiteTask('product', 'stream', PRODUCT_STREAM_SUITE, ['fast-glob', 'node-glob']),
-	productSyncTask: makeBenchSuiteTask('product', 'sync', PRODUCT_SYNC_SUITE, ['fast-glob', 'node-glob', 'tinyglobby']),
+	productSyncTask: makeBenchSuiteTask('product', 'sync', PRODUCT_SYNC_SUITE, ['fast-glob', 'node-glob', 'tinyglobby', 'native']),
 };
 
 export const {

--- a/src/benchmark/suites/product/async.ts
+++ b/src/benchmark/suites/product/async.ts
@@ -4,7 +4,7 @@ import * as bencho from 'bencho';
 
 import * as utils from '../../utils';
 
-type GlobImplementation = 'fast-glob' | 'node-glob' | 'tinyglobby';
+type GlobImplementation = 'fast-glob' | 'native' | 'node-glob' | 'tinyglobby';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GlobImplFunction = (...args: any[]) => Promise<unknown[]>;
 
@@ -15,6 +15,32 @@ class Glob {
 	constructor(cwd: string, pattern: string) {
 		this.#cwd = cwd;
 		this.#pattern = pattern;
+	}
+
+	/**
+	 * Assumptions:
+	 *
+	 * 1. The implementation returns entries with an absolute path, while all other solutions return a relative path.
+	 */
+	public async measureNative(): Promise<void> {
+		const glob = await utils.importAndMeasure(utils.importNativeGlob);
+
+		await this.#measure(async () => {
+			const iterator = await glob.glob(this.#pattern, {
+				cwd: this.#cwd,
+				withFileTypes: true,
+			});
+
+			const entries: string[] = [];
+
+			for await (const dirent of iterator) {
+				if (!dirent.isDirectory()) {
+					entries.push(`${dirent.parentPath}/${dirent.name}`);
+				}
+			}
+
+			return entries;
+		});
 	}
 
 	public async measureNodeGlob(): Promise<void> {
@@ -71,6 +97,11 @@ class Glob {
 	const glob = new Glob(cwd, pattern);
 
 	switch (impl) {
+		case 'native': {
+			await glob.measureNative();
+			break;
+		}
+
 		case 'node-glob': {
 			await glob.measureNodeGlob();
 			break;

--- a/src/benchmark/utils.ts
+++ b/src/benchmark/utils.ts
@@ -2,10 +2,21 @@ import { performance } from 'node:perf_hooks';
 
 import * as bencho from 'bencho';
 
+import type * as fs from 'node:fs';
 import type * as currentVersion from '..';
 import type * as previousVersion from 'fast-glob';
 import type * as glob from 'glob';
 import type * as tg from 'tinyglobby';
+
+type NativeGlobAsynchronous = (pattern: string, options: {
+	cwd: string;
+	withFileTypes: boolean;
+}) => Promise<AsyncIterable<fs.Dirent>>;
+
+type NativeGlobSynchronous = (pattern: string, options: {
+	cwd: string;
+	withFileTypes: boolean;
+}) => fs.Dirent[];
 
 export function timeStart(): number {
 	return performance.now();
@@ -21,6 +32,20 @@ export function getMemory(): number {
 
 export function importCurrentFastGlob(): Promise<typeof currentVersion> {
 	return import('..');
+}
+
+export async function importNativeGlob(): Promise<{
+	glob: NativeGlobAsynchronous;
+	globSync: NativeGlobSynchronous;
+}> {
+	const fs = await import('node:fs');
+
+	return {
+		// @ts-expect-error The current version of @types/node has not definitions for this method.
+		glob: fs.promises.glob as NativeGlobAsynchronous,
+		// @ts-expect-error The current version of @types/node has not definitions for this method.
+		globSync: fs.globSync as NativeGlobSynchronous,
+	};
 }
 
 export function importPreviousFastGlob(): Promise<typeof previousVersion> {


### PR DESCRIPTION
```js
Using ~/work/fast-glob/fast-glob/herebyfile.mjs to run bench:product:async
Starting bench:product:async:flatten
Label               import.time (time)  time (time)       memory (memory)    entries (value)  process.time (time)
------------------  ------------------  ----------------  -----------------  ---------------  -------------------
async fast-glob *   26.634ms ±4.013%    4.651ms ±5.030%   5.628 MiB ±0.187%  6 ±0.000%        59.968ms ±3.300%   
async node-glob *   14.351ms ±5.911%    6.299ms ±5.273%   5.125 MiB ±0.278%  6 ±0.000%        48.276ms ±3.346%   
async tinyglobby *  10.123ms ±8.319%    47.579ms ±3.275%  6.704 MiB ±4.272%  6 ±0.000%        88.102ms ±2.442%   
async native *      1.036ms ±2.193%     4.387ms ±2.011%   4.815 MiB ±0.000%  6 ±0.000%        33.873ms ±2.848%   

Finished bench:product:async:flatten in 46.3s
Starting bench:product:async:deep
Label                import.time (time)  time (time)        memory (memory)     entries (value)  process.time (time)
-------------------  ------------------  -----------------  ------------------  ---------------  -------------------
async fast-glob **   26.468ms ±4.114%    65.136ms ±1.988%   11.056 MiB ±4.916%  17452 ±0.000%    124.669ms ±2.213%  
async node-glob **   14.347ms ±6.571%    159.098ms ±2.562%  25.538 MiB ±1.042%  17452 ±0.000%    209.117ms ±2.287%  
async tinyglobby **  10.097ms ±7.639%    53.567ms ±2.136%   7.193 MiB ±0.651%   17452 ±0.000%    94.315ms ±1.543%   
async native **      1.038ms ±2.062%     244.339ms ±2.632%  35.621 MiB ±0.091%  17452 ±0.000%    282.232ms ±2.533%  

Finished bench:product:async:deep in 2m 22.2s
Starting bench:product:async:partial_flatten
Label                                             import.time (time)  time (time)       memory (memory)    entries (value)  process.time (time)
------------------------------------------------  ------------------  ----------------  -----------------  ---------------  -------------------
async fast-glob {fixtures,out}/{first,second}/*   26.499ms ±3.362%    8.507ms ±4.181%   5.478 MiB ±4.770%  2 ±0.000%        63.454ms ±2.531%   
async node-glob {fixtures,out}/{first,second}/*   14.272ms ±5.187%    8.076ms ±2.599%   5.247 MiB ±0.416%  2 ±0.000%        50.151ms ±1.938%   
async tinyglobby {fixtures,out}/{first,second}/*  10.167ms ±7.808%    48.289ms ±2.593%  6.794 MiB ±4.674%  2 ±0.000%        88.856ms ±1.696%   
async native {fixtures,out}/{first,second}/*      1.055ms ±14.462%    6.767ms ±10.655%  4.959 MiB ±0.001%  2 ±0.000%        37.554ms ±9.651%   

Finished bench:product:async:partial_flatten in 48.1s
Starting bench:product:async:partial_deep
Label                               import.time (time)  time (time)       memory (memory)    entries (value)  process.time (time)
----------------------------------  ------------------  ----------------  -----------------  ---------------  -------------------
async fast-glob {fixtures,out}/**   26.385ms ±3.276%    9.582ms ±3.260%   5.462 MiB ±0.147%  178 ±0.000%      64.260ms ±2.053%   
async node-glob {fixtures,out}/**   14.431ms ±5.393%    10.883ms ±5.062%  5.546 MiB ±0.323%  178 ±0.000%      53.368ms ±2.342%   
async tinyglobby {fixtures,out}/**  10.017ms ±7.614%    48.166ms ±3.056%  6.796 MiB ±3.296%  178 ±0.000%      88.794ms ±1.929%   
async native {fixtures,out}/**      1.044ms ±2.674%     12.361ms ±6.837%  4.926 MiB ±0.249%  178 ±0.000%      42.877ms ±3.490%   

Finished bench:product:async:partial_deep in 49.9s
Starting bench:product:async
```