### PR TITLE
Support AbortSignal to abort the processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This package provides methods for traversing the file system and returning pathn
     * [ignore](#ignore)
     * [suppressErrors](#suppresserrors)
     * [throwErrorOnBrokenSymbolicLink](#throwerroronbrokensymboliclink)
+    * [signal](#signal)
   * [Output control](#output-control)
     * [absolute](#absolute)
     * [markDirectories](#markdirectories)
@@ -404,6 +405,15 @@ By default this package suppress only `ENOENT` errors. Set to `true` to suppress
 Throw an error when symbolic link is broken if `true` or safely return `lstat` call if `false`.
 
 > :book: This option has no effect on errors when reading the symbolic link directory.
+
+#### signal
+
+* Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+* Default: `undefined`
+
+A signal to abort searching for entries on the file system. Works only with asynchronous methods for dynamic and static patterns.
+
+> :book: The abort signal does not interrupt the operation instantly. After the abort signal, there will be a brief period during which the tail of unprocessed but already read directories will be processed. New directories will not be added to the queue for reading, entries found in processed directories will not be emitted. Think of it as a no-op loop because we do not know at what stage of processing the abort signal was triggered.
 
 ### Output control
 

--- a/src/providers/provider.spec.ts
+++ b/src/providers/provider.spec.ts
@@ -85,6 +85,7 @@ describe('Providers → Provider', () => {
 			assert.ok(!actual.stats);
 			assert.ok(actual.throwErrorOnBrokenSymbolicLink === false);
 			assert.strictEqual(typeof actual.transform, 'function');
+			assert.strictEqual(actual.signal, undefined);
 		});
 
 		it('should return options for reader with non-global base', () => {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -48,6 +48,7 @@ export abstract class Provider<T> {
 			stats: this.#settings.stats,
 			throwErrorOnBrokenSymbolicLink: this.#settings.throwErrorOnBrokenSymbolicLink,
 			transform: this.entryTransformer.getTransformer(),
+			signal: this.#settings.signal,
 		};
 	}
 

--- a/src/readers/stream.ts
+++ b/src/readers/stream.ts
@@ -24,7 +24,7 @@ export class ReaderStream extends Reader<Readable> implements IReaderStream {
 	public static(patterns: Pattern[], options: ReaderOptions): Readable {
 		const filepaths = patterns.map((pattern) => this._getFullEntryPath(pattern));
 
-		const stream = new PassThrough({ objectMode: true });
+		const stream = new PassThrough({ objectMode: true, signal: options.signal });
 
 		stream._write = (index: number, _enc, done) => {
 			this.#getEntry(filepaths[index], patterns[index], options)

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -28,6 +28,7 @@ describe('Settings', () => {
 		assert.ok(settings.onlyFiles);
 		assert.ok(settings.unique);
 		assert.strictEqual(settings.cwd, process.cwd());
+		assert.strictEqual(settings.signal, undefined);
 	});
 
 	it('should return instance with custom values', () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -138,6 +138,13 @@ export interface Options {
 	 * @default true
 	 */
 	unique?: boolean;
+	/**
+	 * A signal to abort searching for entries on the file system.
+	 * Works only with asynchronous methods for dynamic and static patterns.
+	 *
+	 * @default undefined
+	 */
+	signal?: AbortSignal;
 }
 
 export default class Settings {
@@ -161,6 +168,7 @@ export default class Settings {
 	public readonly suppressErrors: boolean;
 	public readonly throwErrorOnBrokenSymbolicLink: boolean;
 	public readonly unique: boolean;
+	public readonly signal?: AbortSignal;
 
 	// eslint-disable-next-line complexity
 	constructor(options: Options = {}) {
@@ -184,6 +192,7 @@ export default class Settings {
 		this.suppressErrors = options.suppressErrors ?? false;
 		this.throwErrorOnBrokenSymbolicLink = options.throwErrorOnBrokenSymbolicLink ?? false;
 		this.unique = options.unique ?? true;
+		this.signal = options.signal;
 
 		if (this.onlyDirectories) {
 			this.onlyFiles = false;


### PR DESCRIPTION
### What is the purpose of this pull request?

This is allow to use `AbortSignal` to abort glob progress.

#435

### What changes did you make? (Give an overview)

Just passing the `signal` option to `@nodelib/fs.walk`.

https://github.com/nodelib/nodelib/pull/104