### PR TITLE
ISSUE-480: remove backslashes from the pattern's base directory

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -179,6 +179,16 @@ describe('Managers → Task', () => {
 
 			assert.deepStrictEqual(actual, expected);
 		});
+
+		it('should remove backslashes from the base directory', () => {
+			const expected: PatternsGroup = {
+				"a'b": [String.raw`a\'b/*`],
+			};
+
+			const actual = manager.groupPatternsByBaseDirectory([String.raw`a\'b/*`]);
+
+			assert.deepStrictEqual(actual, expected);
+		});
 	});
 
 	describe('.convertPatternGroupsToTasks', () => {

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -104,7 +104,13 @@ export function groupPatternsByBaseDirectory(patterns: Pattern[]): PatternsGroup
 	const group: PatternsGroup = {};
 
 	return patterns.reduce((collection, pattern) => {
-		const base = utils.pattern.getBaseDirectory(pattern);
+		let base = utils.pattern.getBaseDirectory(pattern);
+
+		/**
+		 * After extracting the basic static part of the pattern, it becomes a path,
+		 * so escaping leads to referencing non-existent paths.
+		 */
+		base = utils.path.removeBackslashes(base);
 
 		if (base in collection) {
 			collection[base].push(pattern);

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -81,6 +81,13 @@ describe('Utils → Path', () => {
 		});
 	});
 
+	describe('.removeBackslashes', () => {
+		it('should return path without backslashes', () => {
+			assert.strictEqual(util.removeBackslashes(String.raw`a\b`), 'ab');
+			assert.strictEqual(util.removeBackslashes(String.raw`a\\\b`), String.raw`ab`);
+		});
+	});
+
 	describe('.convertPathToPattern', () => {
 		it('should return a pattern', () => {
 			assert.strictEqual(util.convertPathToPattern('.{directory}'), String.raw`.\{directory\}`);

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -42,6 +42,10 @@ export function removeLeadingDotSegment(entry: string): string {
 	return entry;
 }
 
+export function removeBackslashes(entry: string): string {
+	return entry.replaceAll('\\', '');
+}
+
 export const escape = IS_WINDOWS_PLATFORM ? escapeWindowsPath : escapePosixPath;
 
 export function escapeWindowsPath(pattern: Pattern): Pattern {


### PR DESCRIPTION
### What is the purpose of this pull request?

This is a fix for #480. The escape characters should not be part of the base static part of the pattern.

Examples of problematic patterns before this changes:

```
fifth\\'s/*
```

### What changes did you make? (Give an overview)

The base static part of the pattern is a path in the file system. The path must not contain escape characters.

We don't have to worry about Windows support, as starting from version 3 of the package, backslashes are always considered escape characters.