### PR TITLE
feat: add custom error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This package provides methods for traversing the file system and returning pathn
     * [fs](#fs)
     * [ignore](#ignore)
     * [suppressErrors](#suppresserrors)
+    * [errorHandler](#errorhandler)
     * [throwErrorOnBrokenSymbolicLink](#throwerroronbrokensymboliclink)
     * [signal](#signal)
   * [Output control](#output-control)
@@ -393,9 +394,31 @@ fg.globSync('*.json', { ignore: ['package-lock.json'] }); // ['package.json']
 * Type: `boolean`
 * Default: `false`
 
-By default this package suppress only `ENOENT` errors. Set to `true` to suppress any error.
+By default this package suppress `ENOENT` errors. Set to `true` to suppress any error.
 
 > :book: Can be useful when the directory has entries with a special level of access.
+
+#### errorHandler
+
+* Type: function (error: ErrnoException) => boolean
+
+Supply a custom error handler that takes the error as argument and allows you to 
+handle errors in a custom way. Return `true` to suppress the error, 
+`false` to throw the error.
+
+```js
+fg.globSync('**', {
+  errorHandler: (error) => {
+    if (error.code === 'ENOENT') {
+      console.error('Directory not found:', error.path);
+      return true;
+    } else {
+      console.error('Error:', error.message);
+      return false;
+    }
+  }
+});
+```
 
 #### throwErrorOnBrokenSymbolicLink
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This package provides methods for traversing the file system and returning pathn
     * [fs](#fs)
     * [ignore](#ignore)
     * [suppressErrors](#suppresserrors)
+    * [errorFilter](#errorfilter)
     * [throwErrorOnBrokenSymbolicLink](#throwerroronbrokensymboliclink)
     * [signal](#signal)
   * [Output control](#output-control)
@@ -402,6 +403,23 @@ fg.globSync('*.json', { ignore: ['package-lock.json'] }); // ['package.json']
 By default this package suppress only `ENOENT` and `ENOTDIR` errors. Set to `true` to suppress any error.
 
 > :book: Can be useful when the directory has entries with a special level of access.
+
+#### errorFilter
+
+* Type: `(error: ErrnoException) => boolean`
+* Default: `undefined`
+
+A function that decides at runtime which errors to suppress and which to throw. Return `true` to suppress the error, `false` to throw it.
+
+The function receives **all** errors, including `ENOENT` and `ENOTDIR`, which are suppressed by default. So if you want to suppress only specific error codes, do not forget to also skip them:
+
+```js
+fg.globSync('**', {
+  errorFilter: (error) => error.code === 'EACCES' || error.code === 'ENOENT' || error.code === 'ENOTDIR',
+});
+```
+
+This option is ignored when the [`suppressErrors`](#suppresserrors) option is enabled.
 
 #### throwErrorOnBrokenSymbolicLink
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This package provides methods for traversing the file system and returning pathn
     * [followSymbolicLinks](#followsymboliclinks)
     * [fs](#fs)
     * [ignore](#ignore)
-    * [suppressErrors](#suppresserrors)
     * [errorFilter](#errorfilter)
     * [throwErrorOnBrokenSymbolicLink](#throwerroronbrokensymboliclink)
     * [signal](#signal)
@@ -395,23 +394,14 @@ fg.globSync(['*.json', '!package-lock.json']);            // ['package.json']
 fg.globSync('*.json', { ignore: ['package-lock.json'] }); // ['package.json']
 ```
 
-#### suppressErrors
-
-* Type: `boolean`
-* Default: `false`
-
-By default this package suppress only `ENOENT` and `ENOTDIR` errors. Set to `true` to suppress any error.
-
-> :book: Can be useful when the directory has entries with a special level of access.
-
 #### errorFilter
 
 * Type: `(error: ErrnoException) => boolean`
 * Default: `undefined`
 
-A function that decides at runtime which errors to suppress and which to throw. Return `true` to suppress the error, `false` to throw it.
+By default this package suppress only `ENOENT` and `ENOTDIR` errors. To suppress errors in a custom way, provide a function that decides whether an error is fatal: return `true` to suppress the error, `false` to throw it.
 
-The function receives **all** errors, including `ENOENT` and `ENOTDIR`, which are suppressed by default. So if you want to suppress only specific error codes, do not forget to also skip them:
+The function receives **all** errors, including `ENOENT` and `ENOTDIR`. So if you want to suppress only specific error codes, do not forget to also skip them:
 
 ```js
 fg.globSync('**', {
@@ -419,7 +409,7 @@ fg.globSync('**', {
 });
 ```
 
-This option is ignored when the [`suppressErrors`](#suppresserrors) option is enabled.
+> :book: Can be useful when the directory has entries with a special level of access.
 
 #### throwErrorOnBrokenSymbolicLink
 

--- a/src/providers/filters/error.spec.ts
+++ b/src/providers/filters/error.spec.ts
@@ -41,14 +41,6 @@ describe('Providers → Filters → Error', () => {
 			assert.ok(isActual);
 		});
 
-		it('should return true for EPERM error when the `suppressErrors` options is enabled', () => {
-			const filter = getFilter({ suppressErrors: true });
-
-			const isActual = filter(tests.errno.getEperm());
-
-			assert.ok(isActual);
-		});
-
 		it('should return false for EPERM error', () => {
 			const filter = getFilter();
 
@@ -71,14 +63,6 @@ describe('Providers → Filters → Error', () => {
 			const isActual = filter(tests.errno.getEnoent());
 
 			assert.ok(!isActual);
-		});
-
-		it('should return true for EPERM error when the `suppressErrors` option is enabled and the `errorFilter` option returns false', () => {
-			const filter = getFilter({ suppressErrors: true, errorFilter: () => false });
-
-			const isActual = filter(tests.errno.getEperm());
-
-			assert.ok(isActual);
 		});
 	});
 });

--- a/src/providers/filters/error.spec.ts
+++ b/src/providers/filters/error.spec.ts
@@ -56,5 +56,29 @@ describe('Providers → Filters → Error', () => {
 
 			assert.ok(!isActual);
 		});
+
+		it('should return true for EPERM error when the `errorFilter` option returns true', () => {
+			const filter = getFilter({ errorFilter: () => true });
+
+			const isActual = filter(tests.errno.getEperm());
+
+			assert.ok(isActual);
+		});
+
+		it('should return false for ENOENT error when the `errorFilter` option returns false', () => {
+			const filter = getFilter({ errorFilter: () => false });
+
+			const isActual = filter(tests.errno.getEnoent());
+
+			assert.ok(!isActual);
+		});
+
+		it('should return true for EPERM error when the `suppressErrors` option is enabled and the `errorFilter` option returns false', () => {
+			const filter = getFilter({ suppressErrors: true, errorFilter: () => false });
+
+			const isActual = filter(tests.errno.getEperm());
+
+			assert.ok(isActual);
+		});
 	});
 });

--- a/src/providers/filters/error.ts
+++ b/src/providers/filters/error.ts
@@ -15,6 +15,18 @@ export default class ErrorFilter {
 	}
 
 	#isNonFatalError(error: ErrnoException): boolean {
-		return utils.errno.isEnoentCodeError(error) || this.#settings.suppressErrors;
+		if (this.#settings.suppressErrors) {
+			return true;
+		}
+
+		if (this.#settings.errorHandler !== undefined) {
+			return this.#settings.errorHandler(error);
+		}
+
+		if (utils.errno.isEnoentCodeError(error)) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/providers/filters/error.ts
+++ b/src/providers/filters/error.ts
@@ -10,10 +10,6 @@ export default class ErrorFilter {
 	}
 
 	#isNonFatalError(error: ErrnoException): boolean {
-		if (this.#settings.suppressErrors) {
-			return true;
-		}
-
 		if (this.#settings.errorFilter !== undefined) {
 			return this.#settings.errorFilter(error);
 		}

--- a/src/providers/filters/error.ts
+++ b/src/providers/filters/error.ts
@@ -10,7 +10,15 @@ export default class ErrorFilter {
 	}
 
 	#isNonFatalError(error: ErrnoException): boolean {
-		return utils.errno.isEnoentCodeError(error) || utils.errno.isEnotdirCodeError(error) || this.#settings.suppressErrors;
+		if (this.#settings.suppressErrors) {
+			return true;
+		}
+
+		if (this.#settings.errorFilter !== undefined) {
+			return this.#settings.errorFilter(error);
+		}
+
+		return utils.errno.isEnoentCodeError(error) || utils.errno.isEnotdirCodeError(error);
 	}
 
 	public getFilter(): ErrorFilterFunction {

--- a/src/readers/reader.spec.ts
+++ b/src/readers/reader.spec.ts
@@ -4,7 +4,13 @@ import * as process from 'node:process';
 import { Stats, StatsMode } from '@nodelib/fs.macchiato';
 import { describe, it } from 'mocha';
 import Settings, { type Options } from '../settings.js';
-import type { Entry, FsStats, Pattern } from '../types/index.js';
+import * as tests from '../tests/index.js';
+import type {
+	Entry,
+	ErrnoException,
+	FsStats,
+	Pattern,
+} from '../types/index.js';
 import { Reader } from './reader.js';
 
 class TestReader extends Reader<never[]> {
@@ -26,6 +32,10 @@ class TestReader extends Reader<never[]> {
 
 	public makeEntry(stats: FsStats, pattern: Pattern): Entry {
 		return this._makeEntry(stats, pattern);
+	}
+
+	public isFatalError(error: ErrnoException): boolean {
+		return this._isFatalError(error);
 	}
 }
 
@@ -74,6 +84,44 @@ describe('Readers → Reader', () => {
 			const actual = reader.makeEntry(new Stats(), pattern);
 
 			assert.ok(actual.stats);
+		});
+	});
+
+	describe('.isFatalError', () => {
+		it('should return false for ENOENT error', () => {
+			const reader = getReader();
+
+			assert.ok(!reader.isFatalError(tests.errno.getEnoent()));
+		});
+
+		it('should return true for EPERM error', () => {
+			const reader = getReader();
+
+			assert.ok(reader.isFatalError(tests.errno.getEperm()));
+		});
+
+		it('should return false for EPERM error when the `suppressErrors` option is enabled', () => {
+			const reader = getReader({ suppressErrors: true });
+
+			assert.ok(!reader.isFatalError(tests.errno.getEperm()));
+		});
+
+		it('should return true for ENOENT error when the `errorFilter` option returns false', () => {
+			const reader = getReader({ errorFilter: () => false });
+
+			assert.ok(reader.isFatalError(tests.errno.getEnoent()));
+		});
+
+		it('should return false for EPERM error when the `errorFilter` option returns true', () => {
+			const reader = getReader({ errorFilter: () => true });
+
+			assert.ok(!reader.isFatalError(tests.errno.getEperm()));
+		});
+
+		it('should return false for EPERM error when the `suppressErrors` option is enabled and the `errorFilter` option returns false', () => {
+			const reader = getReader({ suppressErrors: true, errorFilter: () => false });
+
+			assert.ok(!reader.isFatalError(tests.errno.getEperm()));
 		});
 	});
 });

--- a/src/readers/reader.spec.ts
+++ b/src/readers/reader.spec.ts
@@ -100,12 +100,6 @@ describe('Readers → Reader', () => {
 			assert.ok(reader.isFatalError(tests.errno.getEperm()));
 		});
 
-		it('should return false for EPERM error when the `suppressErrors` option is enabled', () => {
-			const reader = getReader({ suppressErrors: true });
-
-			assert.ok(!reader.isFatalError(tests.errno.getEperm()));
-		});
-
 		it('should return true for ENOENT error when the `errorFilter` option returns false', () => {
 			const reader = getReader({ errorFilter: () => false });
 
@@ -114,12 +108,6 @@ describe('Readers → Reader', () => {
 
 		it('should return false for EPERM error when the `errorFilter` option returns true', () => {
 			const reader = getReader({ errorFilter: () => true });
-
-			assert.ok(!reader.isFatalError(tests.errno.getEperm()));
-		});
-
-		it('should return false for EPERM error when the `suppressErrors` option is enabled and the `errorFilter` option returns false', () => {
-			const reader = getReader({ suppressErrors: true, errorFilter: () => false });
 
 			assert.ok(!reader.isFatalError(tests.errno.getEperm()));
 		});

--- a/src/readers/reader.ts
+++ b/src/readers/reader.ts
@@ -44,6 +44,18 @@ export abstract class Reader<T> {
 	}
 
 	protected _isFatalError(error: ErrnoException): boolean {
-		return !utils.errno.isEnoentCodeError(error) && !this.#settings.suppressErrors;
+		if (this.#settings.suppressErrors) {
+			return false;
+		}
+
+		if (this.#settings.errorHandler !== undefined) {
+			return !this.#settings.errorHandler(error);
+		}
+
+		if (utils.errno.isEnoentCodeError(error)) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/readers/reader.ts
+++ b/src/readers/reader.ts
@@ -47,10 +47,6 @@ export abstract class Reader<T> {
 	}
 
 	protected _isFatalError(error: ErrnoException): boolean {
-		if (this.#settings.suppressErrors) {
-			return false;
-		}
-
 		if (this.#settings.errorFilter !== undefined) {
 			return !this.#settings.errorFilter(error);
 		}

--- a/src/readers/reader.ts
+++ b/src/readers/reader.ts
@@ -47,6 +47,14 @@ export abstract class Reader<T> {
 	}
 
 	protected _isFatalError(error: ErrnoException): boolean {
-		return !utils.errno.isEnoentCodeError(error) && !utils.errno.isEnotdirCodeError(error) && !this.#settings.suppressErrors;
+		if (this.#settings.suppressErrors) {
+			return false;
+		}
+
+		if (this.#settings.errorFilter !== undefined) {
+			return !this.#settings.errorFilter(error);
+		}
+
+		return !utils.errno.isEnoentCodeError(error) && !utils.errno.isEnotdirCodeError(error);
 	}
 }

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -18,6 +18,7 @@ describe('Settings', () => {
 		assert.ok(!settings.onlyDirectories);
 		assert.ok(!settings.stats);
 		assert.ok(!settings.suppressErrors);
+		assert.ok(!settings.errorHandler);
 		assert.ok(!settings.throwErrorOnBrokenSymbolicLink);
 		assert.ok(settings.braceExpansion);
 		assert.ok(settings.caseSensitiveMatch);

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -18,6 +18,7 @@ describe('Settings', () => {
 		assert.ok(!settings.onlyDirectories);
 		assert.ok(!settings.stats);
 		assert.ok(!settings.suppressErrors);
+		assert.ok(!settings.errorFilter);
 		assert.ok(!settings.throwErrorOnBrokenSymbolicLink);
 		assert.ok(settings.braceExpansion);
 		assert.ok(settings.caseSensitiveMatch);

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -17,7 +17,6 @@ describe('Settings', () => {
 		assert.ok(!settings.objectMode);
 		assert.ok(!settings.onlyDirectories);
 		assert.ok(!settings.stats);
-		assert.ok(!settings.suppressErrors);
 		assert.ok(!settings.errorFilter);
 		assert.ok(!settings.throwErrorOnBrokenSymbolicLink);
 		assert.ok(settings.braceExpansion);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 
-import type { FileSystemAdapter, Pattern } from './types';
+import type { ErrnoException, FileSystemAdapter, Pattern } from './types';
 
 export const DEFAULT_FILE_SYSTEM_ADAPTER: FileSystemAdapter = {
 	lstat: fs.lstat,
@@ -126,6 +126,13 @@ export interface Options {
 	 */
 	suppressErrors?: boolean;
 	/**
+	 * Callback for user-defined error handling. Ignored if
+	 * `suppressErrors` is `true`. Return `true` to suppress an error,
+	 * `false` to throw it.
+	 *
+	 */
+	errorHandler?: (error: Error) => boolean;
+	/**
 	 * Throw an error when symbolic link is broken if `true` or safely
 	 * return `lstat` call if `false`.
 	 *
@@ -166,6 +173,7 @@ export default class Settings {
 	public readonly onlyFiles: boolean;
 	public readonly stats: boolean;
 	public readonly suppressErrors: boolean;
+	public readonly errorHandler: ((error: ErrnoException) => boolean) | undefined;
 	public readonly throwErrorOnBrokenSymbolicLink: boolean;
 	public readonly unique: boolean;
 	public readonly signal?: AbortSignal;
@@ -190,7 +198,8 @@ export default class Settings {
 		this.onlyFiles = options.onlyFiles ?? true;
 		this.stats = options.stats ?? false;
 		this.suppressErrors = options.suppressErrors ?? false;
-		this.throwErrorOnBrokenSymbolicLink = options.throwErrorOnBrokenSymbolicLink ?? false;
+		this.errorHandler = options.errorHandler ?? undefined;
+		this.throwErrorOnBrokenSymbolicLink =	options.throwErrorOnBrokenSymbolicLink ?? false;
 		this.unique = options.unique ?? true;
 		this.signal = options.signal;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -120,17 +120,10 @@ export type Options = {
 	 */
 	stats?: boolean;
 	/**
-	 * By default this package suppress only `ENOENT` and `ENOTDIR` errors.
-	 * Set to `true` to suppress any error.
-	 *
-	 * @default false
-	 */
-	suppressErrors?: boolean;
-	/**
 	 * A function that decides whether an error is fatal. Receives all
 	 * errors, including `ENOENT` and `ENOTDIR`, which are suppressed
 	 * by default. Return `true` to suppress the error, `false` to throw
-	 * it. Ignored when the `suppressErrors` option is enabled.
+	 * it.
 	 *
 	 * @default undefined
 	 */
@@ -175,7 +168,6 @@ export default class Settings {
 	public readonly onlyDirectories: boolean;
 	public readonly onlyFiles: boolean;
 	public readonly stats: boolean;
-	public readonly suppressErrors: boolean;
 	public readonly errorFilter: ((error: ErrnoException) => boolean) | undefined;
 	public readonly throwErrorOnBrokenSymbolicLink: boolean;
 	public readonly unique: boolean;
@@ -204,7 +196,6 @@ export default class Settings {
 		this.onlyDirectories = options.onlyDirectories ?? false;
 		this.onlyFiles = options.onlyFiles ?? true;
 		this.stats = options.stats ?? false;
-		this.suppressErrors = options.suppressErrors ?? false;
 		this.errorFilter = options.errorFilter ?? undefined;
 		this.throwErrorOnBrokenSymbolicLink = options.throwErrorOnBrokenSymbolicLink ?? false;
 		this.unique = options.unique ?? true;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import type { FileSystemAdapter, Pattern } from './types/index.js';
+import type { ErrnoException, FileSystemAdapter, Pattern } from './types/index.js';
 
 export const DEFAULT_FILE_SYSTEM_ADAPTER: FileSystemAdapter = {
 	lstat: fs.lstat,
@@ -120,12 +120,21 @@ export type Options = {
 	 */
 	stats?: boolean;
 	/**
-	 * By default this package suppress only `ENOENT` errors.
+	 * By default this package suppress only `ENOENT` and `ENOTDIR` errors.
 	 * Set to `true` to suppress any error.
 	 *
 	 * @default false
 	 */
 	suppressErrors?: boolean;
+	/**
+	 * A function that decides whether an error is fatal. Receives all
+	 * errors, including `ENOENT` and `ENOTDIR`, which are suppressed
+	 * by default. Return `true` to suppress the error, `false` to throw
+	 * it. Ignored when the `suppressErrors` option is enabled.
+	 *
+	 * @default undefined
+	 */
+	errorFilter?: (error: ErrnoException) => boolean;
 	/**
 	 * Throw an error when symbolic link is broken if `true` or safely
 	 * return `lstat` call if `false`.
@@ -167,6 +176,7 @@ export default class Settings {
 	public readonly onlyFiles: boolean;
 	public readonly stats: boolean;
 	public readonly suppressErrors: boolean;
+	public readonly errorFilter: ((error: ErrnoException) => boolean) | undefined;
 	public readonly throwErrorOnBrokenSymbolicLink: boolean;
 	public readonly unique: boolean;
 	public readonly signal?: AbortSignal;
@@ -195,6 +205,7 @@ export default class Settings {
 		this.onlyFiles = options.onlyFiles ?? true;
 		this.stats = options.stats ?? false;
 		this.suppressErrors = options.suppressErrors ?? false;
+		this.errorFilter = options.errorFilter ?? undefined;
 		this.throwErrorOnBrokenSymbolicLink = options.throwErrorOnBrokenSymbolicLink ?? false;
 		this.unique = options.unique ?? true;
 		this.signal = options.signal;


### PR DESCRIPTION
### What is the purpose of this pull request?
Add the option to suppress EACCES, permission denied errors.

This is an error we're seeing in Immich when fast-glob is crawling a directory that contains items that we lack read permission for. We don't want to error out and stop crawling, and we don't want to suppress all errors. This is a reasonable middle road that adds an option, suppressEaccess

Ref: https://github.com/immich-app/immich/issues/12713

In the above bug, a user has a few files in their NAS that wan't accessible. This throws out the whole crawl process even though only a few items are missing

### What changes did you make? (Give an overview)
Add option suppressEacces
Add more conditions in isNonFatalError and _isFatalError
Added documentation in README
