### PR TITLE
feat: support `URL`s in `cwd` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,10 +308,14 @@ fg.win32.convertPathToPattern('\\\\?\\c:\\Program Files (x86)') + '/**/*';
 
 #### cwd
 
-* Type: `string`
+* Type: `string | URL`
 * Default: `process.cwd()`
 
-The current working directory in which to search.
+The current working directory in which to search. A `file:` URL is converted to a path with [`fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl).
+
+```js
+fg.globSync('**', { cwd: new URL('./dir', import.meta.url) });
+```
 
 #### deep
 

--- a/__snapshots__/cwd.e2e.js
+++ b/__snapshots__/cwd.e2e.js
@@ -1,0 +1,155 @@
+exports['Options cwd (URL) {"pattern":"*","options":{"cwd":"<root>/fixtures"}} (sync) 1'] = [
+  "file.md"
+]
+
+exports['Options cwd (URL) {"pattern":"*","options":{"cwd":"<root>/fixtures"}} (async) 1'] = [
+  "file.md"
+]
+
+exports['Options cwd (URL) {"pattern":"*","options":{"cwd":"<root>/fixtures"}} (stream) 1'] = [
+  "file.md"
+]
+
+exports['Options cwd (URL) {"pattern":"**","options":{"cwd":"<root>/fixtures"}} (sync) 1'] = [
+  "file.md",
+  "first/file.md",
+  "first/nested/directory/file.json",
+  "first/nested/directory/file.md",
+  "first/nested/file.md",
+  "second/file.md",
+  "second/nested/directory/file.md",
+  "second/nested/file.md",
+  "third/library/a/book.md",
+  "third/library/b/book.md"
+]
+
+exports['Options cwd (URL) {"pattern":"**","options":{"cwd":"<root>/fixtures"}} (async) 1'] = [
+  "file.md",
+  "first/file.md",
+  "first/nested/directory/file.json",
+  "first/nested/directory/file.md",
+  "first/nested/file.md",
+  "second/file.md",
+  "second/nested/directory/file.md",
+  "second/nested/file.md",
+  "third/library/a/book.md",
+  "third/library/b/book.md"
+]
+
+exports['Options cwd (URL) {"pattern":"**","options":{"cwd":"<root>/fixtures"}} (stream) 1'] = [
+  "file.md",
+  "first/file.md",
+  "first/nested/directory/file.json",
+  "first/nested/directory/file.md",
+  "first/nested/file.md",
+  "second/file.md",
+  "second/nested/directory/file.md",
+  "second/nested/file.md",
+  "third/library/a/book.md",
+  "third/library/b/book.md"
+]
+
+exports['Options cwd (URL) {"pattern":"**/*.md","options":{"cwd":"<root>/fixtures"}} (sync) 1'] = [
+  "file.md",
+  "first/file.md",
+  "first/nested/directory/file.md",
+  "first/nested/file.md",
+  "second/file.md",
+  "second/nested/directory/file.md",
+  "second/nested/file.md",
+  "third/library/a/book.md",
+  "third/library/b/book.md"
+]
+
+exports['Options cwd (URL) {"pattern":"**/*.md","options":{"cwd":"<root>/fixtures"}} (async) 1'] = [
+  "file.md",
+  "first/file.md",
+  "first/nested/directory/file.md",
+  "first/nested/file.md",
+  "second/file.md",
+  "second/nested/directory/file.md",
+  "second/nested/file.md",
+  "third/library/a/book.md",
+  "third/library/b/book.md"
+]
+
+exports['Options cwd (URL) {"pattern":"**/*.md","options":{"cwd":"<root>/fixtures"}} (stream) 1'] = [
+  "file.md",
+  "first/file.md",
+  "first/nested/directory/file.md",
+  "first/nested/file.md",
+  "second/file.md",
+  "second/nested/directory/file.md",
+  "second/nested/file.md",
+  "third/library/a/book.md",
+  "third/library/b/book.md"
+]
+
+exports['Options cwd (URL) {"pattern":"*","options":{"cwd":"<root>/fixtures","onlyFiles":false}} (sync) 1'] = [
+  "file.md",
+  "first",
+  "second",
+  "third"
+]
+
+exports['Options cwd (URL) {"pattern":"*","options":{"cwd":"<root>/fixtures","onlyFiles":false}} (async) 1'] = [
+  "file.md",
+  "first",
+  "second",
+  "third"
+]
+
+exports['Options cwd (URL) {"pattern":"*","options":{"cwd":"<root>/fixtures","onlyFiles":false}} (stream) 1'] = [
+  "file.md",
+  "first",
+  "second",
+  "third"
+]
+
+exports['Options cwd (URL & absolute) {"pattern":"*","options":{"cwd":"<root>/fixtures","absolute":true}} (sync) 1'] = [
+  "<root>/fixtures/file.md"
+]
+
+exports['Options cwd (URL & absolute) {"pattern":"*","options":{"cwd":"<root>/fixtures","absolute":true}} (async) 1'] = [
+  "<root>/fixtures/file.md"
+]
+
+exports['Options cwd (URL & absolute) {"pattern":"*","options":{"cwd":"<root>/fixtures","absolute":true}} (stream) 1'] = [
+  "<root>/fixtures/file.md"
+]
+
+exports['Options cwd (URL & absolute) {"pattern":"**/*.md","options":{"cwd":"<root>/fixtures","absolute":true}} (sync) 1'] = [
+  "<root>/fixtures/file.md",
+  "<root>/fixtures/first/file.md",
+  "<root>/fixtures/first/nested/directory/file.md",
+  "<root>/fixtures/first/nested/file.md",
+  "<root>/fixtures/second/file.md",
+  "<root>/fixtures/second/nested/directory/file.md",
+  "<root>/fixtures/second/nested/file.md",
+  "<root>/fixtures/third/library/a/book.md",
+  "<root>/fixtures/third/library/b/book.md"
+]
+
+exports['Options cwd (URL & absolute) {"pattern":"**/*.md","options":{"cwd":"<root>/fixtures","absolute":true}} (async) 1'] = [
+  "<root>/fixtures/file.md",
+  "<root>/fixtures/first/file.md",
+  "<root>/fixtures/first/nested/directory/file.md",
+  "<root>/fixtures/first/nested/file.md",
+  "<root>/fixtures/second/file.md",
+  "<root>/fixtures/second/nested/directory/file.md",
+  "<root>/fixtures/second/nested/file.md",
+  "<root>/fixtures/third/library/a/book.md",
+  "<root>/fixtures/third/library/b/book.md"
+]
+
+exports['Options cwd (URL & absolute) {"pattern":"**/*.md","options":{"cwd":"<root>/fixtures","absolute":true}} (stream) 1'] = [
+  "<root>/fixtures/file.md",
+  "<root>/fixtures/first/file.md",
+  "<root>/fixtures/first/nested/directory/file.md",
+  "<root>/fixtures/first/nested/file.md",
+  "<root>/fixtures/second/file.md",
+  "<root>/fixtures/second/nested/directory/file.md",
+  "<root>/fixtures/second/nested/file.md",
+  "<root>/fixtures/third/library/a/book.md",
+  "<root>/fixtures/third/library/b/book.md"
+]

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -98,6 +98,6 @@ describe('Settings', () => {
 			cwd: pathToFileURL(process.cwd()),
 		});
 
-		assert.strictEqual(typeof settings.cwd, 'string');
+		assert.strictEqual(settings.cwd, process.cwd());
 	});
 });

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert';
 import * as process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import { describe, it } from 'mocha';
 import Settings, { DEFAULT_FILE_SYSTEM_ADAPTER } from './settings.js';
 
@@ -90,5 +91,13 @@ describe('Settings', () => {
 
 		const settingsPositive = new Settings({ deep: 5 });
 		assert.strictEqual(settingsPositive.deep, 5);
+	});
+
+	it('should transform URL to string on cwd', () => {
+		const settings = new Settings({
+			cwd: pathToFileURL(process.cwd()),
+		});
+
+		assert.strictEqual(typeof settings.cwd, 'string');
 	});
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type { FileSystemAdapter, Pattern } from './types/index.js';
 
 export const DEFAULT_FILE_SYSTEM_ADAPTER: FileSystemAdapter = {
@@ -42,7 +43,7 @@ export type Options = {
 	 *
 	 * @default process.cwd()
 	 */
-	cwd?: string;
+	cwd?: string | URL;
 	/**
 	 * Specifies the maximum depth of a read directory relative to the start
 	 * directory.
@@ -180,7 +181,7 @@ export default class Settings {
 		this.baseNameMatch = options.baseNameMatch ?? false;
 		this.braceExpansion = options.braceExpansion ?? true;
 		this.caseSensitiveMatch = options.caseSensitiveMatch ?? true;
-		this.cwd = options.cwd ?? process.cwd();
+		this.cwd = options.cwd instanceof URL ? fileURLToPath(options.cwd) : options.cwd ?? process.cwd();
 		this.deep = options.deep ?? Infinity;
 		this.dot = options.dot ?? false;
 		this.extglob = options.extglob ?? true;

--- a/src/tests/e2e/options/absolute.e2e.ts
+++ b/src/tests/e2e/options/absolute.e2e.ts
@@ -5,16 +5,8 @@ import * as runner from '../runner.js';
 const CWD = process.cwd();
 const CWD_POSIX = CWD.replaceAll('\\', '/');
 
-function resultTransform(item: string): string {
-	return item
-		.replace(CWD, '<root>')
-		// Backslashes are used on Windows.
-		// The `fixtures` directory is under our control, so we are confident that the conversions are correct.
-		.replaceAll(/[/\\]/g, '/');
-}
-
 runner.suite('Options Absolute', {
-	resultTransform,
+	resultTransform: runner.absoluteResultTransform,
 	tests: [
 		{
 			pattern: 'fixtures/*',
@@ -45,7 +37,7 @@ runner.suite('Options Absolute', {
 });
 
 runner.suite('Options Absolute (ignore)', {
-	resultTransform,
+	resultTransform: runner.absoluteResultTransform,
 	tests: [
 		{
 			pattern: 'fixtures/*/*',
@@ -81,7 +73,7 @@ runner.suite('Options Absolute (ignore)', {
 });
 
 runner.suite('Options Absolute (cwd)', {
-	resultTransform,
+	resultTransform: runner.absoluteResultTransform,
 	tests: [
 		{
 			pattern: '*',
@@ -108,7 +100,7 @@ runner.suite('Options Absolute (cwd)', {
 });
 
 runner.suite('Options Absolute (cwd & ignore)', {
-	resultTransform,
+	resultTransform: runner.absoluteResultTransform,
 	tests: [
 		{
 			pattern: '*/*',

--- a/src/tests/e2e/options/cwd.e2e.ts
+++ b/src/tests/e2e/options/cwd.e2e.ts
@@ -1,0 +1,56 @@
+import * as path from 'node:path';
+import * as process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import * as runner from '../runner.js';
+
+const FIXTURES_URL = pathToFileURL(path.resolve(process.cwd(), 'fixtures'));
+
+runner.suite('Options cwd (URL)', {
+	tests: [
+		{
+			pattern: '*',
+			options: {
+				cwd: FIXTURES_URL,
+			},
+		},
+		{
+			pattern: '**',
+			options: {
+				cwd: FIXTURES_URL,
+			},
+		},
+		{
+			pattern: '**/*.md',
+			options: {
+				cwd: FIXTURES_URL,
+			},
+		},
+		{
+			pattern: '*',
+			options: {
+				cwd: FIXTURES_URL,
+				onlyFiles: false,
+			},
+		},
+	],
+});
+
+runner.suite('Options cwd (URL & absolute)', {
+	resultTransform: runner.absoluteResultTransform,
+	tests: [
+		{
+			pattern: '*',
+			options: {
+				cwd: FIXTURES_URL,
+				absolute: true,
+			},
+		},
+		{
+			pattern: '**/*.md',
+			options: {
+				cwd: FIXTURES_URL,
+				absolute: true,
+			},
+		},
+	],
+});

--- a/src/tests/e2e/runner.ts
+++ b/src/tests/e2e/runner.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert';
 import * as process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import snapshotIt from 'snap-shot-it';
 import { describe, it } from 'mocha';
 import * as fg from '../../index.js';
@@ -92,8 +93,9 @@ function getTestPatterns(test: Test): Pattern[] {
 
 function getTestTitle(test: Test): string {
 	// Replacing placeholders to hide absolute paths from snapshots.
+	const cwd = test.options?.cwd instanceof URL ? fileURLToPath(test.options.cwd) : test.options?.cwd;
 	const replacements = {
-		cwd: test.options?.cwd?.replace(CWD, '<root>'),
+		cwd: cwd?.replace(CWD, '<root>'),
 		ignore: test.options?.ignore?.map((pattern) => pattern.replace(CWD, '<root>')),
 	};
 

--- a/src/tests/e2e/runner.ts
+++ b/src/tests/e2e/runner.ts
@@ -83,6 +83,21 @@ export function suite(name: string, suiteOptions: Suite): void {
 	});
 }
 
+/**
+ * Replaces the current working directory with a placeholder to hide absolute
+ * paths from snapshots.
+ *
+ * The raw value of `process.cwd()` is used to match the platform-specific
+ * separators of absolute entries before they are normalized.
+ */
+export function absoluteResultTransform(item: string): string {
+	return item
+		.replace(process.cwd(), '<root>')
+		// Backslashes are used on Windows.
+		// The `fixtures` directory is under our control, so we are confident that the conversions are correct.
+		.replaceAll(/[/\\]/g, '/');
+}
+
 function getSuiteTests(tests: Test[] | Test[][]): Test[] {
 	return tests.flat();
 }
@@ -93,7 +108,8 @@ function getTestPatterns(test: Test): Pattern[] {
 
 function getTestTitle(test: Test): string {
 	// Replacing placeholders to hide absolute paths from snapshots.
-	const cwd = test.options?.cwd instanceof URL ? fileURLToPath(test.options.cwd) : test.options?.cwd;
+	// On Windows, `fileURLToPath` returns a path with backslashes, so it is converted to the POSIX form.
+	const cwd = test.options?.cwd instanceof URL ? fileURLToPath(test.options.cwd).replaceAll('\\', '/') : test.options?.cwd;
 	const replacements = {
 		cwd: cwd?.replace(CWD, '<root>'),
 		ignore: test.options?.ignore?.map((pattern) => pattern.replace(CWD, '<root>')),


### PR DESCRIPTION
### What is the purpose of this pull request?
Hi! Every big glob library (`glob`, `globby`, `tinyglobby`) except this one supports `URL`s in the `cwd` option, so for consistency I'm proposing adding it here too.

Since `globby` uses this library, adding support for this here would mean `globby` could drop its custom handling of `URL`s, and as such it could drop one whole dependency in `globby`!!

I've made sure the implementation is the same as [what `globby` does](https://github.com/sindresorhus/unicorn-magic/blob/6614e1e/node.js#L9).

### What changes did you make? (Give an overview)
I've changed the `Options` interface's `cwd` property to `string | URL`, and changed the settings handler to convert the `URL` to a string if applicable.

I've also enabled `esModuleInterop` in the `tsconfig.json`, since due to an `fdir` update, it looks like typescript does not compile without this option enabled.

<img width="1540" height="158" alt="image" src="https://github.com/user-attachments/assets/a04dda31-cb5b-4bd1-a62f-d2623137a7f3" />

Doing this required me to change the `snap-shot-it` import to a default import:
<img width="1542" height="153" alt="image" src="https://github.com/user-attachments/assets/b17228f6-61d9-4046-a05a-79733b4e3707" />
