### PR TITLE
suppress ENOTDIR errors similar to ENOENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ fg.globSync('*.json', { ignore: ['package-lock.json'] }); // ['package.json']
 * Type: `boolean`
 * Default: `false`
 
-By default this package suppress only `ENOENT` errors. Set to `true` to suppress any error.
+By default this package suppress only `ENOENT` and `ENOTDIR` errors. Set to `true` to suppress any error.
 
 > :book: Can be useful when the directory has entries with a special level of access.
 

--- a/src/providers/filters/error.spec.ts
+++ b/src/providers/filters/error.spec.ts
@@ -33,6 +33,14 @@ describe('Providers → Filters → Error', () => {
 			assert.ok(isActual);
 		});
 
+		it('should return true for ENOTDIR error', () => {
+			const filter = getFilter();
+
+			const isActual = filter(tests.errno.getEnotdir());
+
+			assert.ok(isActual);
+		});
+
 		it('should return true for EPERM error when the `suppressErrors` options is enabled', () => {
 			const filter = getFilter({ suppressErrors: true });
 

--- a/src/providers/filters/error.ts
+++ b/src/providers/filters/error.ts
@@ -10,7 +10,7 @@ export default class ErrorFilter {
 	}
 
 	#isNonFatalError(error: ErrnoException): boolean {
-		return utils.errno.isEnoentCodeError(error) || this.#settings.suppressErrors;
+		return utils.errno.isEnoentCodeError(error) || utils.errno.isEnotdirCodeError(error) || this.#settings.suppressErrors;
 	}
 
 	public getFilter(): ErrorFilterFunction {

--- a/src/readers/reader.ts
+++ b/src/readers/reader.ts
@@ -47,6 +47,6 @@ export abstract class Reader<T> {
 	}
 
 	protected _isFatalError(error: ErrnoException): boolean {
-		return !utils.errno.isEnoentCodeError(error) && !this.#settings.suppressErrors;
+		return !utils.errno.isEnoentCodeError(error) && !utils.errno.isEnotdirCodeError(error) && !this.#settings.suppressErrors;
 	}
 }

--- a/src/tests/utils/errno.ts
+++ b/src/tests/utils/errno.ts
@@ -11,6 +11,10 @@ export function getEnoent(): ErrnoException {
 	return new SystemError('ENOENT', 'no such file or directory');
 }
 
+export function getEnotdir(): ErrnoException {
+	return new SystemError('ENOTDIR', 'not a directory');
+}
+
 export function getEperm(): ErrnoException {
 	return new SystemError('EPERM', 'operation not permitted');
 }

--- a/src/utils/errno.spec.ts
+++ b/src/utils/errno.spec.ts
@@ -13,4 +13,18 @@ describe('Utils → Errno', () => {
 			assert.ok(!util.isEnoentCodeError(tests.errno.getEperm()));
 		});
 	});
+
+	describe('.isEnotdirCodeError', () => {
+		it('should return true for ENOTDIR error', () => {
+			assert.ok(util.isEnotdirCodeError(tests.errno.getEnotdir()));
+		});
+
+		it('should return false for ENOENT error', () => {
+			assert.ok(!util.isEnotdirCodeError(tests.errno.getEnoent()));
+		});
+
+		it('should return false for EPERM error', () => {
+			assert.ok(!util.isEnotdirCodeError(tests.errno.getEperm()));
+		});
+	});
 });

--- a/src/utils/errno.ts
+++ b/src/utils/errno.ts
@@ -3,3 +3,7 @@ import type { ErrnoException } from '../types/index.js';
 export function isEnoentCodeError(error: ErrnoException): boolean {
 	return error.code === 'ENOENT';
 }
+
+export function isEnotdirCodeError(error: ErrnoException): boolean {
+	return error.code === 'ENOTDIR';
+}


### PR DESCRIPTION
### What is the purpose of this pull request?
This PR includes ENOTDIR as a suppressed file system error in the same way that ENOENT is. I would make the case that they are spiritually similar when dealing with glob resolution ("a path to this file could not be found") and thus should be treated the same way. If you disagree that is fine, I will not be offended.

### What changes did you make? (Give an overview)
Added checks for ENOTDIR when determining if an error is fatal