### PR TITLE
fix: validate negative deep option values

### DIFF
--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -66,4 +66,30 @@ describe('Settings', () => {
 
 		assert.strictEqual(settings.fs.readdirSync, customReaddirSync);
 	});
+
+	it('should throw an error when the "deep" option is negative', () => {
+		assert.throws(
+			() => new Settings({ deep: -1 }),
+			{
+				name: 'TypeError',
+				message: 'options.deep must be a non-negative number, received: -1',
+			},
+		);
+
+		assert.throws(
+			() => new Settings({ deep: -10 }),
+			{
+				name: 'TypeError',
+				message: 'options.deep must be a non-negative number, received: -10',
+			},
+		);
+	});
+
+	it('should accept zero and positive values for the "deep" option', () => {
+		const settingsZero = new Settings({ deep: 0 });
+		assert.strictEqual(settingsZero.deep, 0);
+
+		const settingsPositive = new Settings({ deep: 5 });
+		assert.strictEqual(settingsPositive.deep, 5);
+	});
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -172,6 +172,10 @@ export default class Settings {
 
 	// eslint-disable-next-line complexity
 	constructor(options: Options = {}) {
+		if (options.deep !== undefined && options.deep < 0) {
+			throw new TypeError(`options.deep must be a non-negative number, received: ${options.deep}`);
+		}
+
 		this.absolute = options.absolute ?? false;
 		this.baseNameMatch = options.baseNameMatch ?? false;
 		this.braceExpansion = options.braceExpansion ?? true;


### PR DESCRIPTION
## Summary

This PR adds validation for the `deep` option to throw a `TypeError` when a negative value is provided.

**Fixes #500**

## Problem

Currently, `fast-glob` accepts negative values for the `deep` option without any error or warning, even though negative depth doesn't make logical sense:

```javascript
import fg from 'fast-glob';

const results = await fg('**/*.js', { 
  deep: -10,  // This is accepted but semantically invalid
  cwd: '.' 
});
```

This can lead to:
- Unexpected behavior in consuming code
- Unclear semantics (what does negative depth mean?)
- Potential bugs that are hard to track down

## Solution

Add validation at the start of the `Settings` constructor to throw a `TypeError` when `deep` is negative:

```javascript
if (options.deep !== undefined && options.deep < 0) {
  throw new TypeError(`options.deep must be a non-negative number, received: ${options.deep}`);
}
```

## Test plan

- [x] Added unit tests for negative `deep` values (-1, -10)
- [x] Added tests confirming zero and positive values still work correctly
- [x] Verified validation runs before other option processing

## Notes

The build currently has a pre-existing issue with `fdir` and `@types/picomatch` dependencies (TS1259 error). The new tests follow the existing test patterns and were verified manually with `ts-node`.
