### PR TITLE
fix(tasks): keep absolute patterns separate from root cwd task

### DIFF
--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -131,26 +131,35 @@ describe('Managers → Task', () => {
 			assert.deepStrictEqual(actual, expected);
 		});
 
-		it('should keep absolute patterns in separate tasks when mixed with a relative root pattern', () => {
-			const absolutePattern = '/absolute/path/*.ts';
+		it('should not merge the absolute pattern into the global task when it is mixed with a pattern referring to the root', () => {
 			const expected = [
-				tests.task.builder().base('/absolute/path').positive(absolutePattern).build(),
-				tests.task.builder().base('.').positive('*.config.ts').build(),
+				tests.task.builder().base('/absolute/path').positive('/absolute/path/*.ts').negative('*.md').build(),
+				tests.task.builder().base('.').positive('*.config.ts').negative('*.md').build(),
 			];
 
-			const actual = manager.convertPatternsToTasks([absolutePattern, '*.config.ts'], [], /* dynamic */ true);
+			const actual = manager.convertPatternsToTasks(['/absolute/path/*.ts', '*.config.ts'], ['*.md'], /* dynamic */ true);
 
 			assert.deepStrictEqual(actual, expected);
 		});
 
-		it('should keep absolute patterns in separate tasks when mixed with a relative root pattern that triggers global merge', () => {
-			const absolutePattern = '/absolute/path/*.ts';
+		it('should keep the absolute pattern outside of the global task when the global merge is applied', () => {
 			const expected = [
-				tests.task.builder().base('/absolute/path').positive(absolutePattern).build(),
-				tests.task.builder().base('.').positive('*').positive('*.config.ts').build(),
+				tests.task.builder().base('/absolute/path').positive('/absolute/path/*.ts').negative('*.md').build(),
+				tests.task.builder().base('.').positive('*').positive('*.config.ts').negative('*.md').build(),
 			];
 
-			const actual = manager.convertPatternsToTasks([absolutePattern, '*', '*.config.ts'], [], /* dynamic */ true);
+			const actual = manager.convertPatternsToTasks(['*', '*.config.ts', '/absolute/path/*.ts'], ['*.md'], /* dynamic */ true);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should keep the original order of tasks when the global merge is not applied', () => {
+			const expected = [
+				tests.task.builder().base('a').positive('a/*').build(),
+				tests.task.builder().base('/absolute/path').positive('/absolute/path/*.ts').build(),
+			];
+
+			const actual = manager.convertPatternsToTasks(['a/*', '/absolute/path/*.ts'], [], /* dynamic */ true);
 
 			assert.deepStrictEqual(actual, expected);
 		});

--- a/src/managers/tasks.spec.ts
+++ b/src/managers/tasks.spec.ts
@@ -130,6 +130,30 @@ describe('Managers → Task', () => {
 
 			assert.deepStrictEqual(actual, expected);
 		});
+
+		it('should keep absolute patterns in separate tasks when mixed with a relative root pattern', () => {
+			const absolutePattern = '/absolute/path/*.ts';
+			const expected = [
+				tests.task.builder().base('/absolute/path').positive(absolutePattern).build(),
+				tests.task.builder().base('.').positive('*.config.ts').build(),
+			];
+
+			const actual = manager.convertPatternsToTasks([absolutePattern, '*.config.ts'], [], /* dynamic */ true);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should keep absolute patterns in separate tasks when mixed with a relative root pattern that triggers global merge', () => {
+			const absolutePattern = '/absolute/path/*.ts';
+			const expected = [
+				tests.task.builder().base('/absolute/path').positive(absolutePattern).build(),
+				tests.task.builder().base('.').positive('*').positive('*.config.ts').build(),
+			];
+
+			const actual = manager.convertPatternsToTasks([absolutePattern, '*', '*.config.ts'], [], /* dynamic */ true);
+
+			assert.deepStrictEqual(actual, expected);
+		});
 	});
 
 	describe('.getPositivePatterns', () => {

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -71,29 +71,26 @@ export function convertPatternsToTasks(positive: Pattern[], negative: Pattern[],
 	const patternsOutsideCurrentDirectory = utils.pattern.getPatternsOutsideCurrentDirectory(positive);
 	const patternsInsideCurrentDirectory = utils.pattern.getPatternsInsideCurrentDirectory(positive);
 
-	/*
-	 * Absolute patterns must be handled as separate tasks and must never be merged into the
-	 * root `.` task, because their base directory is independent of `cwd`. Without this
-	 * separation, mixing an absolute pattern (e.g. `/abs/path/*.ts`) with a relative root
-	 * pattern (e.g. `*.config.ts`) causes the absolute pattern to be pulled into the root
-	 * task. Entries found via the root traversal are then tested against the absolute pattern
-	 * without the path prefix, so they never match and are silently dropped. See #497.
-	 */
-	const absolutePatterns = patternsInsideCurrentDirectory.filter((pattern) => utils.pattern.isAbsolute(pattern));
-	const relativePatterns = patternsInsideCurrentDirectory.filter((pattern) => !utils.pattern.isAbsolute(pattern));
-
 	const outsideCurrentDirectoryGroup = groupPatternsByBaseDirectory(patternsOutsideCurrentDirectory);
-	const absoluteGroup = groupPatternsByBaseDirectory(absolutePatterns);
-	const insideCurrentDirectoryGroup = groupPatternsByBaseDirectory(relativePatterns);
+	const insideCurrentDirectoryGroup = groupPatternsByBaseDirectory(patternsInsideCurrentDirectory);
 
 	tasks.push(...convertPatternGroupsToTasks(outsideCurrentDirectoryGroup, negative, dynamic));
-	tasks.push(...convertPatternGroupsToTasks(absoluteGroup, negative, dynamic));
 
 	/*
 	 * For the sake of reducing future accesses to the file system, we merge all tasks within the current directory
 	 * into a global task, if at least one pattern refers to the root (`.`). In this case, the global task covers the rest.
+	 *
+	 * Absolute patterns must not participate in this merge, because their base directory is independent of the current
+	 * directory. Otherwise, entries found by traversing the current directory will be matched against the absolute
+	 * pattern without the path prefix and never match.
 	 */
 	if ('.' in insideCurrentDirectoryGroup) {
+		const [absolutePatterns, relativePatterns] = utils.pattern.partitionAbsoluteAndRelative(patternsInsideCurrentDirectory);
+
+		if (absolutePatterns.length > 0) {
+			tasks.push(...convertPatternGroupsToTasks(groupPatternsByBaseDirectory(absolutePatterns), negative, dynamic));
+		}
+
 		tasks.push(convertPatternGroupToTask('.', relativePatterns, negative, dynamic));
 	} else {
 		tasks.push(...convertPatternGroupsToTasks(insideCurrentDirectoryGroup, negative, dynamic));

--- a/src/managers/tasks.ts
+++ b/src/managers/tasks.ts
@@ -71,17 +71,30 @@ export function convertPatternsToTasks(positive: Pattern[], negative: Pattern[],
 	const patternsOutsideCurrentDirectory = utils.pattern.getPatternsOutsideCurrentDirectory(positive);
 	const patternsInsideCurrentDirectory = utils.pattern.getPatternsInsideCurrentDirectory(positive);
 
+	/*
+	 * Absolute patterns must be handled as separate tasks and must never be merged into the
+	 * root `.` task, because their base directory is independent of `cwd`. Without this
+	 * separation, mixing an absolute pattern (e.g. `/abs/path/*.ts`) with a relative root
+	 * pattern (e.g. `*.config.ts`) causes the absolute pattern to be pulled into the root
+	 * task. Entries found via the root traversal are then tested against the absolute pattern
+	 * without the path prefix, so they never match and are silently dropped. See #497.
+	 */
+	const absolutePatterns = patternsInsideCurrentDirectory.filter((pattern) => utils.pattern.isAbsolute(pattern));
+	const relativePatterns = patternsInsideCurrentDirectory.filter((pattern) => !utils.pattern.isAbsolute(pattern));
+
 	const outsideCurrentDirectoryGroup = groupPatternsByBaseDirectory(patternsOutsideCurrentDirectory);
-	const insideCurrentDirectoryGroup = groupPatternsByBaseDirectory(patternsInsideCurrentDirectory);
+	const absoluteGroup = groupPatternsByBaseDirectory(absolutePatterns);
+	const insideCurrentDirectoryGroup = groupPatternsByBaseDirectory(relativePatterns);
 
 	tasks.push(...convertPatternGroupsToTasks(outsideCurrentDirectoryGroup, negative, dynamic));
+	tasks.push(...convertPatternGroupsToTasks(absoluteGroup, negative, dynamic));
 
 	/*
 	 * For the sake of reducing future accesses to the file system, we merge all tasks within the current directory
 	 * into a global task, if at least one pattern refers to the root (`.`). In this case, the global task covers the rest.
 	 */
 	if ('.' in insideCurrentDirectoryGroup) {
-		tasks.push(convertPatternGroupToTask('.', patternsInsideCurrentDirectory, negative, dynamic));
+		tasks.push(convertPatternGroupToTask('.', relativePatterns, negative, dynamic));
 	} else {
 		tasks.push(...convertPatternGroupsToTasks(insideCurrentDirectoryGroup, negative, dynamic));
 	}

--- a/src/tests/e2e/patterns/root.e2e.ts
+++ b/src/tests/e2e/patterns/root.e2e.ts
@@ -75,3 +75,16 @@ runner.suite('Patterns Root (cwd)', {
 		},
 	],
 });
+
+runner.suite('Patterns Root (mix of absolute and relative patterns)', {
+	tests: [
+		// The absolute pattern must not be merged into the global task rooted at the current
+		// directory, otherwise its entries will never match and will be silently dropped.
+		{
+			pattern: [`${CWD}/fixtures/first/*.md`, '*.md'],
+			options: { cwd: 'fixtures' },
+			issue: 497,
+			expected: () => [`${CWD}/fixtures/first/file.md`, 'file.md'],
+		},
+	],
+});


### PR DESCRIPTION
## Problem

Mixing an absolute pattern (e.g. `/abs/path/*.ts`) with a relative root pattern (e.g. `*.config.ts`) silently drops all matches for the absolute pattern.

**Reproduction:**

```js
import fg from 'fast-glob';
import path from 'node:path';

// Files: /tmp/testdir/test.ts  and  /tmp/testdir/playwright.config.ts
// cwd:   /tmp/testdir

const results = fg.sync([
  path.join(process.cwd(), '*.ts'),  // absolute: /tmp/testdir/*.ts
  '*.config.ts',                     // relative root
], { cwd: process.cwd() });

// Expected: ['test.ts', 'playwright.config.ts']
// Actual:   ['playwright.config.ts']  ← absolute pattern silently dropped
```

## Root Cause

`getPatternsOutsideCurrentDirectory` only identifies patterns starting with `../` or `./..` as "outside". Absolute paths like `/abs/path/*.ts` pass through as "inside current directory".

When `patternsInsideCurrentDirectory` contained both absolute and relative patterns, and at least one relative pattern had base `.`, the root-task merge optimization gathered **all** inside patterns (including absolute ones) into a single task rooted at `.`. Entries traversed from cwd were then matched against the absolute pattern *without* the absolute path prefix, so they never matched and were silently dropped.

## Fix

Extract absolute patterns from `patternsInsideCurrentDirectory` before the root-merge check, and route them through their own `groupPatternsByBaseDirectory` → task pipeline. This keeps them fully independent of cwd.

```
patternsInsideCurrentDirectory
  ├── absolutePatterns  → absoluteGroup  → separate tasks (never merged into '.')
  └── relativePatterns  → insideCurrentDirectoryGroup  → root-merge logic (unchanged)
```

## Tests

Two new unit tests added in `src/managers/tasks.spec.ts`:

- `should keep absolute patterns in separate tasks when mixed with a relative root pattern`
- `should keep absolute patterns in separate tasks when mixed with a relative root pattern that triggers global merge`

All 255 tests pass.

Fixes #497