### PR TITLE
fix: don't stat negative patterns in static reads

### DIFF
--- a/src/providers/async.spec.ts
+++ b/src/providers/async.spec.ts
@@ -75,6 +75,18 @@ describe('Providers → ProviderAsync', () => {
 			assert.deepStrictEqual(actual, expected);
 		});
 
+		it('should pass only positive patterns to the static reader (#499)', async () => {
+			const provider = getProvider();
+			const task = tests.task.builder().base('.').static().positive('root/file.txt').negative('*.bup.txt').build();
+			const entry = tests.entry.builder().path('root/file.txt').build();
+
+			await getEntries(provider, task, entry);
+
+			// Negative patterns are exclusion filters, not paths to stat. Passing
+			// them to the static reader makes it lstat bogus paths like `!*.bup.txt`.
+			assert.deepStrictEqual(provider.reader.static.firstCall.args[0], task.positive);
+		});
+
 		it('should throw error', async () => {
 			const provider = getProvider();
 			const task = tests.task.builder().base('.').positive('*').build();

--- a/src/providers/async.ts
+++ b/src/providers/async.ts
@@ -28,6 +28,6 @@ export class ProviderAsync extends Provider<Promise<EntryItem[]>> {
 			return this.#reader.dynamic(root, options);
 		}
 
-		return this.#reader.static(task.patterns, options);
+		return this.#reader.static(task.positive, options);
 	}
 }

--- a/src/providers/stream.spec.ts
+++ b/src/providers/stream.spec.ts
@@ -91,6 +91,18 @@ describe('Providers → ProviderStream', () => {
 			assert.deepStrictEqual(actual, expected);
 		});
 
+		it('should pass only positive patterns to the static reader (#499)', async () => {
+			const provider = getProvider();
+			const task = tests.task.builder().base('.').static().positive('root/file.txt').negative('*.bup.txt').build();
+			const entry = tests.entry.builder().path('root/file.txt').file().build();
+
+			await getEntries(provider, task, entry);
+
+			// Negative patterns are exclusion filters, not paths to stat. Passing
+			// them to the static reader makes it lstat bogus paths like `!*.bup.txt`.
+			assert.deepStrictEqual(provider.reader.static.firstCall.args[0], task.positive);
+		});
+
 		it('should emit error to the transform stream', (done) => {
 			const provider = getProvider();
 			const task = tests.task.builder().base('.').positive('*').build();

--- a/src/providers/stream.ts
+++ b/src/providers/stream.ts
@@ -39,6 +39,6 @@ export class ProviderStream extends Provider<Readable> {
 			return this.#reader.dynamic(root, options);
 		}
 
-		return this.#reader.static(task.patterns, options);
+		return this.#reader.static(task.positive, options);
 	}
 }

--- a/src/providers/sync.spec.ts
+++ b/src/providers/sync.spec.ts
@@ -69,5 +69,19 @@ describe('Providers → ProviderSync', () => {
 			assert.strictEqual(provider.reader.static.callCount, 1);
 			assert.deepStrictEqual(actual, expected);
 		});
+
+		it('should pass only positive patterns to the static reader (#499)', () => {
+			const provider = getProvider();
+			const task = tests.task.builder().base('.').static().positive('root/file.txt').negative('*.bup.txt').build();
+			const entry = tests.entry.builder().path('root/file.txt').file().build();
+
+			provider.reader.static.returns([entry]);
+
+			provider.read(task);
+
+			// Negative patterns are exclusion filters, not paths to stat. Passing
+			// them to the static reader makes it lstat bogus paths like `!*.bup.txt`.
+			assert.deepStrictEqual(provider.reader.static.firstCall.args[0], task.positive);
+		});
 	});
 });

--- a/src/providers/sync.ts
+++ b/src/providers/sync.ts
@@ -28,6 +28,6 @@ export class ProviderSync extends Provider<EntryItem[]> {
 			return this.#reader.dynamic(root, options);
 		}
 
-		return this.#reader.static(task.patterns, options);
+		return this.#reader.static(task.positive, options);
 	}
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes #499 — for a **static** pattern combined with an `ignore` pattern, fast-glob calls `lstat` on a bogus path such as `!*.bup.txt`. This is silently swallowed as `ENOENT` in most environments, but surfaces as `EIO` in some (e.g. Podman/Hyper-V on Windows, where the literal `*` in the path is invalid).

```js
const fastGlob = require("fast-glob");
fastGlob.sync("foo.txt", { ignore: ["*.bup.txt"] });
// correct result ['foo.txt'], but internally lstats `<cwd>/!*.bup.txt`
```

### What changes did you make? (Give an overview)

**Root cause:** `convertPatternGroupToTask` builds `task.patterns = positive + negative` (negatives re-encoded as `!...`). The static providers passed `task.patterns` to `reader.static()`, which `lstat`s every entry — including the negative patterns.

**Fix:** pass `task.positive` to the static reader instead of `task.patterns`, in all three providers (sync/async/stream). Negative patterns are exclusion filters, not candidate paths — `ignore` handling is already applied via `entryFilter`, which `Provider#_getReaderOptions` builds from `task.positive` and `task.negative` independently of what is passed to the reader. So only real candidate paths are now stat'd, and ignore semantics are unchanged. The dynamic path was never affected (it walks the base directory and filters).

**Tests:** added a regression to each provider spec asserting the static reader receives only `task.positive` (not the negative patterns). Verified behaviorally that `ignore` still excludes static matches (`fastGlob.sync("foo.bup.txt", { ignore: ["*.bup.txt"] })` → `[]`).

- Unit suite: `256 passing`.
- Lint: clean.
- (Pre-existing, unrelated to this change: 3 `CaseSensitiveMatch` e2e tests fail on case-insensitive filesystems; they involve no `ignore` patterns.)