### PR TITLE
fix: keep question mark segments out of the base directory (#380)

### DIFF
--- a/src/tests/e2e/patterns/regular.e2e.ts
+++ b/src/tests/e2e/patterns/regular.e2e.ts
@@ -503,3 +503,11 @@ runner.suite('Patterns Regular (segmented lists)', {
 		{ pattern: '{book.xml,library/**/a/book.md}', options: { cwd: 'fixtures/third' } },
 	],
 });
+
+runner.suite('Patterns Regular (question mark in the base directory)', {
+	tests: [
+		{ pattern: 'fi?st/file.md', options: { cwd: 'fixtures' }, issue: 380, expected: () => ['first/file.md'] },
+		{ pattern: '?????/file.md', options: { cwd: 'fixtures' }, issue: 380, expected: () => ['first/file.md'] },
+		{ pattern: 'fixtures/fi?st/file.md', issue: 380, expected: () => ['fixtures/first/file.md'] },
+	],
+});

--- a/src/utils/pattern.spec.ts
+++ b/src/utils/pattern.spec.ts
@@ -343,6 +343,30 @@ describe('Utils → Pattern', () => {
 
 			assert.strictEqual(actual, expected);
 		});
+
+		it('should returns the current directory for a leading question mark segment', () => {
+			const expected = '.';
+
+			const actual = util.getBaseDirectory('?/file.txt');
+
+			assert.strictEqual(actual, expected);
+		});
+
+		it('should not treat a question mark segment as a part of the base directory', () => {
+			const expected = 'root';
+
+			const actual = util.getBaseDirectory('root/a?b/file.txt');
+
+			assert.strictEqual(actual, expected);
+		});
+
+		it('should keep an escaped question mark segment as a part of the base directory', () => {
+			const expected = '?';
+
+			const actual = util.getBaseDirectory(String.raw`\?/file.txt`);
+
+			assert.strictEqual(actual, expected);
+		});
 	});
 
 	describe('.hasGlobStar', () => {

--- a/src/utils/pattern.ts
+++ b/src/utils/pattern.ts
@@ -9,6 +9,7 @@ import type { MicromatchOptions, Pattern, PatternRe } from '../types';
 
 const GLOBSTAR = '**';
 const ESCAPE_SYMBOL = '\\';
+const QUESTION_MARK_SYMBOL = '?';
 
 const COMMON_GLOB_SYMBOLS_RE = /[*?]|^!/;
 const REGEX_CHARACTER_CLASS_SYMBOLS_RE = /\[[^[]*]/;
@@ -134,7 +135,45 @@ export function isPatternRelatedToParentDirectory(pattern: Pattern): boolean {
 }
 
 export function getBaseDirectory(pattern: Pattern): string {
-	return globParent(pattern, { flipBackslashes: false });
+	const base = globParent(pattern, { flipBackslashes: false });
+
+	/**
+	 * `glob-parent` relies on `is-glob`, which does not treat a path segment whose only glob
+	 * metacharacter is an unescaped `?` as dynamic (see is-glob#21). As a result the base can still
+	 * contain a dynamic segment, which makes directory traversal start from a non-existent directory
+	 * (see #380). If the extracted base contains a `?`, cut it back to the segment preceding the
+	 * first unescaped `?`.
+	 */
+	if (!base.includes(QUESTION_MARK_SYMBOL)) {
+		return base;
+	}
+
+	const segmentIndex = getFirstUnescapedQuestionMarkSegmentIndex(pattern);
+
+	if (segmentIndex === -1) {
+		return base;
+	}
+
+	return segmentIndex === 0 ? '.' : pattern.split('/').slice(0, segmentIndex).join('/');
+}
+
+function getFirstUnescapedQuestionMarkSegmentIndex(pattern: Pattern): number {
+	return pattern.split('/').findIndex((segment) => hasUnescapedQuestionMark(segment));
+}
+
+function hasUnescapedQuestionMark(segment: string): boolean {
+	for (let index = 0; index < segment.length; index++) {
+		if (segment[index] === ESCAPE_SYMBOL) {
+			index++;
+			continue;
+		}
+
+		if (segment[index] === QUESTION_MARK_SYMBOL) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 export function hasGlobStar(pattern: Pattern): boolean {


### PR DESCRIPTION
### What is the purpose of this pull request?

Bug fix for #380: dynamic patterns whose only wildcard in an early segment is a `?` return nothing.

```js
require('fast-glob').sync('?/test'); // [] — expected ['a/test']
require('fast-glob').sync('fi?st/file.md', { cwd: 'fixtures' }); // [] — expected ['first/file.md']
```

### What changes did you make? (Give an overview)

`getBaseDirectory` uses `glob-parent`, which relies on `is-glob`. `is-glob` does not treat a path segment whose only glob metacharacter is an unescaped `?` as dynamic (is-glob#21), so `glob-parent('?/test')` returns `'?'` instead of `'.'`. fast-glob then keeps that dynamic segment in the base and starts traversal from a literal, non-existent directory, matching nothing.

The fix: when the extracted base still contains a `?`, cut it back to the segment preceding the first unescaped `?`. Patterns without a `?` in the base are unchanged, and escaped `\?` segments (real directories named `?`) are preserved.

Added unit tests for `getBaseDirectory` and e2e regression tests (`fi?st/file.md`, `?????/file.md`, `fixtures/fi?st/file.md`) against the existing fixtures.

Closes #380
