### PR TITLE
fix: package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "node": "^22.13.0 || >=24"
   },
   "type": "module",
-  "main": "out/index.js",
-  "typings": "out/index.d.ts",
+  "exports": {
+    "types": "./out/index.d.ts",
+    "default": "./out/index.js"
+  },
   "files": [
     "out",
     "!out/{benchmark,tests}",
@@ -39,7 +41,7 @@
     "eslint": "^10.7.0",
     "eslint-config-mrmlnc": "^6.1.0",
     "execa": "^10.0.0",
-    "fast-glob": "^3.3.3",
+    "fast-glob-v3": "npm:fast-glob@^3.3.3",
     "glob": "^13.0.6",
     "hereby": "^1.15.1",
     "mocha": "^11.7.6",

--- a/src/benchmark/utils.ts
+++ b/src/benchmark/utils.ts
@@ -2,7 +2,7 @@ import { performance } from 'node:perf_hooks';
 import * as process from 'node:process';
 import type * as fs from 'node:fs';
 import * as bencho from 'bencho';
-import type previousVersion from 'fast-glob';
+import type previousVersion from 'fast-glob-v3';
 import type * as glob from 'glob';
 import type * as tg from 'tinyglobby';
 import type * as currentVersion from '../index.js';
@@ -24,7 +24,7 @@ export async function importCurrentFastGlob(): Promise<typeof currentVersion> {
 }
 
 export async function importPreviousFastGlob(): Promise<typeof previousVersion> {
-	const { default: previousFastGlob } = await import('fast-glob');
+	const { default: previousFastGlob } = await import('fast-glob-v3');
 
 	return previousFastGlob;
 }


### PR DESCRIPTION
### What is the purpose of this pull request?
the exports of this package were misconfigured ever since it switched to es modules, which use an `exports` field :+1:

the structure of the exports are based on what `globby` does, since it's pure esm too
https://github.com/sindresorhus/globby/blob/v16.2.4/package.json

since the exports are properly defined now, i had to change how the old version was being imported in the tests, due to [self-referencing](https://nodejs.org/api/packages.html#self-referencing-a-package-using-its-name) happening otherwise

### What changes did you make? (Give an overview)
- added `exports` field that defines both types and normal imports
- changed the imports of the old version to `fast-glob-v3`, which is defined in `package.json` to point to `npm:fast-glob@^3.3.3`
