### PR TITLE
test: rewrite stream merge tests to verify behavior instead of implementation details

### DIFF
--- a/src/utils/stream.spec.ts
+++ b/src/utils/stream.spec.ts
@@ -43,6 +43,19 @@ describe('Utils → Stream', () => {
 			});
 		});
 
+		it('should support asynchronous iteration', async () => {
+			const first = stream.Readable.from(['one']);
+			const second = stream.Readable.from(['two']);
+
+			const expected = ['one', 'two'];
+
+			const mergedStream: AsyncIterable<string> = util.merge([first, second]);
+
+			const actual = await Array.fromAsync(mergedStream);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
 		it('should propagate first error into merged stream (first)', (done) => {
 			const first = new stream.Readable({
 				read() {

--- a/src/utils/stream.spec.ts
+++ b/src/utils/stream.spec.ts
@@ -3,49 +3,97 @@ import * as stream from 'node:stream';
 import { describe, it } from 'mocha';
 import * as util from './stream.js';
 
+function concat<T>(fn: (data: T[]) => void): stream.Writable {
+	const data: T[] = [];
+
+	return new stream.Writable({
+		objectMode: true,
+		write(chunk: T, _encoding, callback): void {
+			data.push(chunk);
+
+			callback();
+		},
+		final(callback): void {
+			fn(data);
+
+			callback();
+		},
+	});
+}
+
 describe('Utils → Stream', () => {
 	describe('.merge', () => {
-		it('should merge two streams into one stream', () => {
-			const first = new stream.PassThrough();
-			const second = new stream.PassThrough();
+		it('should merge two streams into one stream', (done) => {
+			const first = stream.Readable.from(['one']);
+			const second = stream.Readable.from(['two']);
 
-			const expected = 3;
-
-			const mergedStream = util.merge([first, second]);
-
-			const actual = mergedStream.listenerCount('close');
-
-			assert.strictEqual(actual, expected);
-		});
-
-		it('should propagate errors into merged stream', (done) => {
-			const first = new stream.PassThrough();
-			const second = new stream.PassThrough();
-
-			const expected = [1, 2, 3];
+			const expected = ['one', 'two'];
 
 			const mergedStream = util.merge([first, second]);
 
-			const actual: number[] = [];
-
-			mergedStream.on('error', (error: number) => {
-				actual.push(error);
-			});
-
-			mergedStream.once('finish', () => {
-				assert.deepStrictEqual(actual, expected);
+			stream.pipeline([
+				mergedStream,
+				concat((actual: string[]) => {
+					assert.deepStrictEqual(actual, expected);
+				}),
+			], (error) => {
+				assert.ifError(error);
 
 				done();
 			});
-
-			first.emit('error', 1);
-			second.emit('error', 2);
-			mergedStream.emit('error', 3);
 		});
 
-		it('should propagate close event to source streams', (done) => {
-			const first = new stream.PassThrough();
-			const second = new stream.PassThrough();
+		it('should propagate first error into merged stream (first)', (done) => {
+			const first = new stream.Readable({
+				read() {
+					this.destroy(new Error('1'));
+				},
+			});
+			const second = stream.Readable.from([]);
+
+			const expected = '1';
+
+			const mergedStream = util.merge([first, second]);
+
+			stream.pipeline([
+				mergedStream,
+				concat(() => {
+					assert.fail('Should not reach the concat callback');
+				}),
+			], (error) => {
+				assert.strictEqual(error?.message, expected);
+
+				done();
+			});
+		});
+
+		it('should propagate first error into merged stream (second)', (done) => {
+			const first = stream.Readable.from([]);
+			const second = new stream.Readable({
+				read() {
+					this.destroy(new Error('2'));
+				},
+			});
+
+			const expected = '2';
+
+			const mergedStream = util.merge([first, second]);
+
+			stream.pipeline([
+				mergedStream,
+				concat(() => {
+					assert.fail('Should not reach the concat callback');
+				}),
+			], (error) => {
+				assert.strictEqual(error?.message, expected);
+
+				done();
+			});
+		});
+
+		it('should propagate destroy to source streams', (done) => {
+			const first = stream.Readable.from([]);
+			const second = stream.Readable.from([]);
 
 			const mergedStream = util.merge([first, second]);
 
@@ -53,20 +101,39 @@ describe('Utils → Stream', () => {
 
 			const actual: number[] = [];
 
+			let closeCount = 0;
+
 			first.once('close', () => {
+				closeCount++;
+
 				actual.push(1);
+
+				checkCloses();
 			});
 			second.once('close', () => {
+				closeCount++;
+
 				actual.push(2);
+
+				checkCloses();
+			});
+			mergedStream.once('close', () => {
+				closeCount++;
+
+				checkCloses();
 			});
 
-			mergedStream.once('finish', () => {
+			mergedStream.destroy();
+
+			function checkCloses(): void {
+				if (closeCount !== 3) {
+					return;
+				}
+
 				assert.deepStrictEqual(actual, expected);
 
 				done();
-			});
-
-			mergedStream.emit('close');
+			}
 		});
 	});
 });

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,7 +1,7 @@
 import type { Readable } from 'node:stream';
 import merge2 from 'merge2';
 
-export function merge(streams: Readable[]): NodeJS.ReadableStream {
+export function merge(streams: Readable[]): Readable {
 	const mergedStream = merge2(streams);
 
 	for (const stream of streams) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "es2024",
-		"lib": ["es2024"],
+		"lib": ["es2024", "esnext.array"],
 		"module": "nodenext",
 		"moduleResolution": "nodenext",
 		"resolveJsonModule": true,


### PR DESCRIPTION
### What is the purpose of this pull request?

The tests for the `.merge` stream utility assert implementation details — listener counts and manually emitted `error`/`close` events. This rewrites them to verify observable behavior: data flow through `stream.pipeline`, error propagation from destroyed source streams, `destroy` propagation to source streams, and asynchronous iteration.

### What changes did you make? (Give an overview)

- Ported the behavior-based tests from #373 by @phated (thanks!) with minor adaptations to the current code style. All of them pass against the existing `merge2`-based implementation unchanged, so this PR keeps `merge2` and takes only the test improvement.
- Added an asynchronous iteration test: `for await…of` consumers are the reason the merged stream exists, but the contract had no coverage — a regression would not fail any test.
- Aligned the `merge` return type from `NodeJS.ReadableStream` to `Readable`: the merged stream is a `PassThrough`-like stream at runtime, and the honest type makes the `destroy` test possible without casts. The public `globStream` signature is unaffected.
- Added the `esnext.array` library to `tsconfig.json` for the `Array.fromAsync` type definitions used by the new test. The API itself is available in all supported Node.js versions.