### PR TITLE
fix: use basename for `name` field of static-pattern entries in object mode

### DIFF
--- a/src/readers/reader.spec.ts
+++ b/src/readers/reader.spec.ts
@@ -85,6 +85,18 @@ describe('Readers → Reader', () => {
 
 			assert.ok(actual.stats);
 		});
+
+		it('should return created entry with basename as `name` for a pattern with a directory part', () => {
+			const reader = getReader();
+			const pattern = './directory/config.json';
+			const stats = new Stats({ mode: StatsMode.File });
+
+			const actual = reader.makeEntry(stats, pattern);
+
+			assert.strictEqual(actual.name, 'config.json');
+			assert.strictEqual(actual.path, pattern);
+			assert.strictEqual(actual.dirent.name, 'config.json');
+		});
 	});
 
 	describe('.isFatalError', () => {

--- a/src/readers/reader.ts
+++ b/src/readers/reader.ts
@@ -33,10 +33,11 @@ export abstract class Reader<T> {
 	}
 
 	protected _makeEntry(stats: FsStats, pattern: Pattern): Entry {
+		const name = path.basename(pattern);
 		const entry: Entry = {
-			name: pattern,
+			name,
 			path: pattern,
-			dirent: utils.fs.createDirentFromStats(pattern, stats),
+			dirent: utils.fs.createDirentFromStats(name, stats),
 		};
 
 		if (this.#settings.stats) {


### PR DESCRIPTION

## Problem

Fixes #487.

With `objectMode: true`, entries produced from a **static** pattern (e.g. `./package.json`)
expose `name` equal to the whole pattern string, while entries produced from a **dynamic**
pattern (e.g. `./*.json`) expose `name` equal to the real basename, as documented in the
README ("name (`string`) — the last part of the path (basename)"). This makes the shape of
the returned entry, and of `entry.dirent.name`, inconsistent depending on how a match was
found, even though both point at the same file.

Empirical reproduction (Node v22.23.1, built `out/`, see counterfactual section below):

```
STATIC (./package.json):
[ { name: './package.json', path: './package.json', dirent: DirentFromStats { name: './package.json', ... } } ]

DYNAMIC (./*.json) -> package.json entry:
[ { dirent: Dirent { name: 'package.json', ... }, name: 'package.json', path: 'package.json' } ]
```

## Root cause

`src/readers/reader.ts:35-41`, `Reader#_makeEntry`:

```ts
protected _makeEntry(stats: FsStats, pattern: Pattern): Entry {
	const entry: Entry = {
		name: pattern,
		path: pattern,
		dirent: utils.fs.createDirentFromStats(pattern, stats),
	};
	...
```

This method backs the static-pattern path only (`ReaderStream#static` in
`src/readers/stream.ts`, used by both `ReaderSync#static` and `ReaderAsync#static`). It uses
the raw `pattern` string for both `name` and the synthetic `Dirent`'s `name`, instead of
deriving the basename. The dynamic path (`Reader#dynamic`) delegates to `@nodelib/fs.walk`,
which already returns real `fs.Dirent` entries with a correct basename `name`, so the two
code paths silently diverged.

## Fix

`src/readers/reader.ts`: derive the basename once with `path.basename(pattern)` and use it
for both `entry.name` and the name passed into `createDirentFromStats`. `entry.path` is left
untouched (still the full pattern, matching existing behavior and the dynamic path's `path`
semantics).

```ts
protected _makeEntry(stats: FsStats, pattern: Pattern): Entry {
	const name = path.basename(pattern);
	const entry: Entry = {
		name,
		path: pattern,
		dirent: utils.fs.createDirentFromStats(name, stats),
	};
	...
```

No changes to `src/utils/fs.ts`: `createDirentFromStats(name, stats)` was already generic;
only the caller passed the wrong value.

## Test

Added a regression test in `src/readers/reader.spec.ts` (`.makeEntry` suite) using a pattern
with a directory part (`./directory/config.json`), asserting `entry.name` and
`entry.dirent.name` are the basename `config.json` while `entry.path` stays the full pattern.
The pre-existing test in the same suite uses a bare `config.json` pattern (no directory
component), so it does not change under the fix (basename of a bare filename is itself) and
still passes.
