### PR TITLE
fix: require directories for static patterns with a trailing slash

### DIFF
--- a/src/providers/filters/entry.spec.ts
+++ b/src/providers/filters/entry.spec.ts
@@ -279,6 +279,24 @@ describe('Providers → Filters → Entry', () => {
 					options: { dot: false },
 				});
 			});
+
+			it('should reject a file entry whose path already has a trailing slash', () => {
+				const entry = tests.entry.builder().path('root/file.txt/').file().build();
+
+				reject(entry, {
+					positive: ['root/file.txt/'],
+					options: { onlyFiles: false },
+				});
+			});
+
+			it('should accept a directory entry whose path already has a trailing slash', () => {
+				const entry = tests.entry.builder().path('root/directory/').directory().build();
+
+				accept(entry, {
+					positive: ['root/directory/'],
+					options: { onlyFiles: false },
+				});
+			});
 		});
 	});
 

--- a/src/providers/filters/entry.ts
+++ b/src/providers/filters/entry.ts
@@ -38,6 +38,11 @@ export default class EntryFilter {
 
 		const isDirectory = entry.dirent.isDirectory();
 
+		// A trailing slash requires a directory, even for statically resolved paths.
+		if (!isDirectory && filepath.endsWith('/')) {
+			return false;
+		}
+
 		if (this.#onlyFileFilter(isDirectory) || this.#onlyDirectoryFilter(isDirectory)) {
 			return false;
 		}

--- a/src/tests/e2e/patterns/static.e2e.ts
+++ b/src/tests/e2e/patterns/static.e2e.ts
@@ -15,6 +15,60 @@ runner.suite('Patterns Static (cwd)', {
 	],
 });
 
+runner.suite('Patterns Static (trailing slash)', {
+	tests: [
+		{
+			pattern: 'fixtures/file.md/',
+			issue: 458,
+			expected: () => [],
+		},
+		{
+			pattern: 'fixtures/file.md/',
+			options: { onlyFiles: false },
+			issue: 458,
+			expected: () => [],
+		},
+		{
+			pattern: 'file.md/',
+			options: { cwd: 'fixtures', onlyFiles: false },
+			expected: () => [],
+		},
+		{
+			pattern: 'fixtures/*.md/',
+			options: { onlyFiles: false },
+			expected: () => [],
+		},
+		{
+			pattern: 'fixtures/first/',
+			options: { onlyFiles: false },
+			expected: () => ['fixtures/first/'],
+		},
+		{
+			pattern: ['fixtures/file.md/', 'fixtures/file.md'],
+			expected: () => ['fixtures/file.md'],
+		},
+		{
+			pattern: ['fixtures/file.md', 'fixtures/file.md/'],
+			options: { unique: false },
+			expected: () => ['fixtures/file.md'],
+		},
+		{
+			pattern: ['fixtures/file.md/', 'fixtures/first/'],
+			options: { onlyFiles: false },
+			expected: () => ['fixtures/first/'],
+		},
+		{
+			pattern: ['fixtures/file.md', '!fixtures/file.md/'],
+			expected: () => ['fixtures/file.md'],
+		},
+		{
+			pattern: 'fixtures/first/',
+			options: { onlyFiles: false, ignore: ['fixtures/first/'] },
+			expected: () => [],
+		},
+	],
+});
+
 runner.suite('Patterns Static (ignore)', {
 	tests: [
 		// Files


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes #458.

When `file.md` is a regular file, `globSync('file.md/', {onlyFiles: false})` currently returns `['file.md/']`, while the dynamic pattern `'*.md/'` correctly returns `[]`. The same inconsistency affects the async and stream APIs and also reproduces on macOS.

### What changes did you make? (Give an overview)

Static readers resolve the filesystem path before statting it, which removes the trailing slash, but retain the original pattern as the entry path. Reject non-directory entries whose paths end in `/` before matching patterns. This preserves directory matches and allows a separate ordinary file pattern in the same request to match normally.

Add two filter tests and ten end-to-end cases exercised through sync, async and stream APIs. They cover the reported failure, custom `cwd`, dynamic-pattern consistency, directories, mixed patterns, disabled deduplication, and negative/ignore patterns.

Checked related open and closed PRs before implementation; prior trailing-slash changes do not cover this static-file case. Open #516 changes static entry names and does not overlap this filter fix.

Validation on macOS with Node.js 24.19.0:

- Before the fix: the new file filter test and 18 new end-to-end checks fail for the reported behavior.
- `npm run build`: passes, including compile, lint and 279 unit tests.
- `SNAPSHOT_SKIP_PRUNING=1 npm run test:e2e`: 1,401 pass; 9 existing platform-specific skips, unchanged from baseline.
- `git diff --check`: passes.

Prepared and independently reviewed with Codex; validation was run locally.
