### PR TITLE
Avoid duplicate trailing separators with markDirectories

### DIFF
--- a/src/providers/transformers/entry.spec.ts
+++ b/src/providers/transformers/entry.spec.ts
@@ -80,6 +80,36 @@ describe('Providers → Transformers → Entry', () => {
 			assert.strictEqual(actual, expected);
 		});
 
+		it('should preserve an existing trailing slash when the `markDirectories` option is enabled', () => {
+			const transformer = getTransformer({ markDirectories: true });
+			const entry = tests.entry.builder().path('root/directory/').directory().build();
+
+			const actual = transformer(entry);
+
+			assert.strictEqual(actual, 'root/directory/');
+		});
+
+		it('should preserve an existing trailing slash in object mode without mutating the entry', () => {
+			const transformer = getTransformer({ markDirectories: true, objectMode: true });
+			const entry = tests.entry.builder().path('root/directory/').directory().build();
+
+			const actual = transformer(entry);
+
+			assert.deepStrictEqual(actual, entry);
+			assert.notStrictEqual(actual, entry);
+			assert.strictEqual(entry.path, 'root/directory/');
+		});
+
+		it('should preserve the filesystem root when the `absolute` and `markDirectories` options are enabled', () => {
+			const transformer = getTransformer({ absolute: true, markDirectories: true });
+			const { root } = path.parse(process.cwd());
+			const entry = tests.entry.builder().path(root).directory().build();
+
+			const actual = transformer(entry);
+
+			assert.strictEqual(actual, root);
+		});
+
 		it('should return correct entry when the `absolute` and `markDirectories` options is enabled', () => {
 			const transformer = getTransformer({ absolute: true, markDirectories: true });
 			const entry = tests.entry.builder().path('root/directory').directory().build();

--- a/src/providers/transformers/entry.ts
+++ b/src/providers/transformers/entry.ts
@@ -21,7 +21,7 @@ export default class EntryTransformer {
 			filepath = utils.string.flatHeavilyConcatenatedString(filepath);
 		}
 
-		if (this.#settings.markDirectories && entry.dirent.isDirectory()) {
+		if (this.#settings.markDirectories && entry.dirent.isDirectory() && !filepath.endsWith(this.#pathSeparatorSymbol)) {
 			filepath += this.#pathSeparatorSymbol;
 		}
 

--- a/src/tests/e2e/options/mark-directories.e2e.ts
+++ b/src/tests/e2e/options/mark-directories.e2e.ts
@@ -8,5 +8,40 @@ runner.suite('Options MarkDirectories', {
 				markDirectories: true,
 			},
 		},
+		{
+			pattern: 'fixtures/first/',
+			options: {
+				onlyFiles: false,
+				markDirectories: true,
+			},
+			expected: () => ['fixtures/first/'],
+		},
+		{
+			pattern: 'first/',
+			options: {
+				cwd: 'fixtures',
+				onlyFiles: false,
+				markDirectories: true,
+			},
+			expected: () => ['first/'],
+		},
+		{
+			pattern: 'fixtures/first/',
+			options: {
+				absolute: true,
+				onlyFiles: false,
+				markDirectories: true,
+			},
+			resultTransform: runner.absoluteResultTransform,
+			expected: () => ['<root>/fixtures/first/'],
+		},
+		{
+			pattern: 'fixtures/fi*/',
+			options: {
+				onlyFiles: false,
+				markDirectories: true,
+			},
+			expected: () => ['fixtures/first/'],
+		},
 	],
 });


### PR DESCRIPTION
### What is the purpose of this pull request?

Prevent `markDirectories` from adding a second trailing slash to a static directory match. With the existing fixtures, `globSync('fixtures/first/', {onlyFiles: false, markDirectories: true})` returns `['fixtures/first//']`, while the equivalent dynamic pattern already returns `['fixtures/first/']`. This also affects async and stream results.

### What changes did you make? (Give an overview)

Append the directory marker only when the transformed path does not already end with the output separator. Check after absolute conversion so ordinary absolute directories still receive a marker and filesystem roots do not receive a duplicate separator.

Add three transformer tests and four end-to-end cases exercised through sync, async and stream APIs. They cover string and object output, filesystem roots, custom cwd, absolute paths and dynamic-pattern consistency.

Checked related open and closed PRs before implementation. The older extra-slash fixes in #43 and #215 prevent entry mutation; this case starts with an existing trailing slash. Open #516 and #517 change static entry names and filtering respectively, and neither covers this output transformation.

Validation on macOS with Node.js 24.19.0:

- Before the fix: three new unit assertions and six end-to-end checks fail with duplicated separators.
- `npm run build`: passes, including compile, lint and 280 unit tests.
- `SNAPSHOT_SKIP_PRUNING=1 npm run test:e2e`: 1,383 pass, 9 existing platform-specific skips.
- `git diff --check`: passes.

Prepared and independently reviewed with Codex; validation was run locally.